### PR TITLE
feat: html helper + test

### DIFF
--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -13,6 +13,7 @@
 
 namespace BEdita\WebTools\View\Helper;
 
+use Cake\Utility\Inflector;
 use Cake\View\Helper\HtmlHelper as CakeHtmlHelper;
 
 /**
@@ -33,12 +34,12 @@ class HtmlHelper extends CakeHtmlHelper
         if (isset($this->getView()->viewVars['_title'])) {
             return $this->getView()->viewVars['_title'];
         }
-        $title = '';
-        if (isset($this->getView()->request->params['controller'])) {
-            $title = $this->getView()->request->params['controller'];
-        }
-        if (isset($this->getView()->request->params['action'])) {
-            $title .= sprintf(' - %s', $this->getView()->request->params['action']);
+        $title = Inflector::humanize($this->getView()->request->getParam('controller', ''));
+        $suffix = Inflector::humanize($this->getView()->request->getParam('action', ''));
+        if (empty($title)) {
+            $title = $suffix;
+        } elseif (!empty($suffix)) {
+            $title .= sprintf(' - %s', $suffix);
         }
 
         return $title;

--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2018 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\WebTools\View\Helper;
+
+use Cake\View\Helper\HtmlHelper as CakeHtmlHelper;
+
+/**
+ * Html helper.
+ * It extends {@see \Cake\View\Helper\HtmlHelper} Cake Html Helper
+ */
+class HtmlHelper extends CakeHtmlHelper
+{
+    /**
+     * Title for template pages
+     * If `_title` view var is set, return it
+     * Otherwise return controller name (and action name if set)
+     *
+     * @return string
+     */
+    public function title() : string
+    {
+        if (isset($this->getView()->viewVars['_title'])) {
+            return $this->getView()->viewVars['_title'];
+        }
+        $title = '';
+        if (isset($this->getView()->request->params['controller'])) {
+            $title = $this->getView()->request->params['controller'];
+        }
+        if (isset($this->getView()->request->params['action'])) {
+            $title .= sprintf(' - %s', $this->getView()->request->params['action']);
+        }
+
+        return $title;
+    }
+}

--- a/tests/TestCase/View/Helper/HtmlHelperTest.php
+++ b/tests/TestCase/View/Helper/HtmlHelperTest.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2018 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+namespace BEdita\WebTools\Test\TestCase\View\Helper;
+
+use BEdita\WebTools\View\Helper\HtmlHelper;
+use Cake\TestSuite\TestCase;
+use Cake\View\View;
+
+/**
+ * {@see \BEdita\WebTools\View\Helper\HtmlHelper} Test Case
+ *
+ * @coversDefaultClass \BEdita\WebTools\View\Helper\HtmlHelper
+ */
+class HtmlHelperTest extends TestCase
+{
+    /**
+     * Test subject
+     *
+     * @var \BEdita\WebTools\View\Helper\HtmlHelper
+     */
+    public $Html;
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setUp() : void
+    {
+        parent::setUp();
+
+        // create helper
+        $this->Html = new HtmlHelper(new View());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function tearDown() : void
+    {
+        unset($this->Html);
+
+        parent::tearDown();
+    }
+
+    /**
+     * Data provider for `testTitle` test case.
+     *
+     * @return array
+     */
+    public function titleProvider() : array
+    {
+        return [
+            'empty string' => [
+                null,
+                null,
+                null,
+                '',
+            ],
+            '_title' => [
+                null,
+                null,
+                'My title',
+                'My title',
+            ],
+            'title from controller' => [
+                'My Controller',
+                null,
+                null,
+                'My Controller',
+            ],
+            'title from controller, action' => [
+                'My Controller',
+                'My Action',
+                null,
+                'My Controller - My Action',
+            ],
+            'title from controller, action' => [
+                'My Controller',
+                'My Action',
+                'My title',
+                'My title',
+            ],
+        ];
+    }
+
+    /**
+     * Test `title` method
+     *
+     * @dataProvider titleProvider()
+     * @covers ::title()
+     * @param string|null $controllerName The controller name
+     * @param string|null $actionName The action name
+     * @param string|null $viewVarTitle The title
+     * @param string $expected The expected title
+     * @return void
+     */
+    public function testTitle(?string $controllerName, ?string $actionName, ?string $viewVarTitle, string $expected) : void
+    {
+        $this->Html->getView()->request->params['controller'] = $controllerName;
+        $this->Html->getView()->request->params['action'] = $actionName;
+        $this->Html->getView()->viewVars['_title'] = $viewVarTitle;
+        $actual = $this->Html->title();
+        static::assertEquals($expected, $actual);
+    }
+}

--- a/tests/TestCase/View/Helper/HtmlHelperTest.php
+++ b/tests/TestCase/View/Helper/HtmlHelperTest.php
@@ -72,20 +72,20 @@ class HtmlHelperTest extends TestCase
                 'My title',
             ],
             'title from controller' => [
-                'My Controller',
+                'my_controller',
                 null,
                 null,
                 'My Controller',
             ],
             'title from controller, action' => [
-                'My Controller',
-                'My Action',
+                'my_controller',
+                'my_action',
                 null,
                 'My Controller - My Action',
             ],
             'title from controller, action' => [
-                'My Controller',
-                'My Action',
+                'my_controller',
+                'my_action',
                 'My title',
                 'My title',
             ],
@@ -105,8 +105,8 @@ class HtmlHelperTest extends TestCase
      */
     public function testTitle(?string $controllerName, ?string $actionName, ?string $viewVarTitle, string $expected) : void
     {
-        $this->Html->getView()->request->params['controller'] = $controllerName;
-        $this->Html->getView()->request->params['action'] = $actionName;
+        $this->Html->getView()->request = $this->Html->getView()->request->withParam('controller', $controllerName);
+        $this->Html->getView()->request = $this->Html->getView()->request->withParam('action', $actionName);
         $this->Html->getView()->viewVars['_title'] = $viewVarTitle;
         $actual = $this->Html->title();
         static::assertEquals($expected, $actual);


### PR DESCRIPTION
This provides a basic `HtmlHelper` with `title` method (+ test).

Title method returns:

 1. `_title` if set
 2. `request->params['controller']` (if `request->params['controller']` is not empty, but `request->params['action']` is empty)
 3. `request->params['controller'] - request->params['action']` (if `request->params['controller']` is not empty, and `request->params['action']` is not empty)
 4. empty string otherwise