### PR TITLE
meta methods in html helper

### DIFF
--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -83,9 +83,9 @@ class HtmlHelper extends CakeHtmlHelper
             $docType = $data['docType'];
         } else {
             $docType = Configure::read('docType');
-        }
-        if (empty($docType)) {
-            $docType = 'xhtml-strict';
+            if (empty($docType)) {
+                $docType = 'xhtml-strict';
+            }
         }
         $html .= $this->metaCss($docType);
 

--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -110,8 +110,12 @@ class HtmlHelper extends CakeHtmlHelper
         if (empty($description)) {
             return '';
         }
+        $html = $this->meta('description', h(strip_tags($description)));
+        if ($html == null) {
+            $html = '';
+        }
 
-        return $this->meta('description', h(strip_tags($description)));
+        return $html;
     }
 
     /**
@@ -125,11 +129,15 @@ class HtmlHelper extends CakeHtmlHelper
         if (empty($creator)) {
             return '';
         }
-
-        return $this->meta([
+        $html = $this->meta([
             'name' => 'author',
             'content' => h($creator),
         ]);
+        if ($html == null) {
+            $html = '';
+        }
+
+        return $html;
     }
 
     /**
@@ -143,11 +151,15 @@ class HtmlHelper extends CakeHtmlHelper
         if ($docType === 'html5') {
             return '';
         }
-
-        return $this->meta([
+        $html = $this->meta([
             'http-equiv' => 'Content-Style-Type',
             'content' => 'text/css',
         ]);
+        if ($html == null) {
+            $html = '';
+        }
+
+        return $html;
     }
 
     /**
@@ -165,11 +177,15 @@ class HtmlHelper extends CakeHtmlHelper
         if (!empty($project['version'])) {
             $version = $project['version'];
         }
-
-        return $this->meta([
+        $html = $this->meta([
             'name' => 'generator',
             'content' => trim(sprintf('%s %s', $project['name'], $version)),
         ]);
+        if ($html == null) {
+            $html = '';
+        }
+
+        return $html;
     }
 
     /**
@@ -217,10 +233,13 @@ class HtmlHelper extends CakeHtmlHelper
     {
         $html = '';
         foreach ($data as $attribute => $val) {
-            $html .= $this->meta([
+            $tmp = $this->meta([
                 'property' => sprintf('og:%s', $attribute),
                 'content' => $val,
             ]);
+            if ($tmp != null) {
+                $html .= $tmp;
+            }
         }
 
         return $html;
@@ -262,10 +281,13 @@ class HtmlHelper extends CakeHtmlHelper
     {
         $html = '';
         foreach ($data as $attribute => $val) {
-            $html .= $this->meta([
+            $tmp = $this->meta([
                 'property' => sprintf('twitter:%s', $attribute),
                 'content' => $val,
             ]);
+            if ($tmp != null) {
+                $html .= $tmp;
+            }
         }
 
         return $html;

--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -237,7 +237,7 @@ class HtmlHelper extends CakeHtmlHelper
                 'property' => sprintf('og:%s', $attribute),
                 'content' => $val,
             ]);
-            if ($tmp != null) {
+            if ($tmp !== null) {
                 $html .= $tmp;
             }
         }
@@ -285,7 +285,7 @@ class HtmlHelper extends CakeHtmlHelper
                 'property' => sprintf('twitter:%s', $attribute),
                 'content' => $val,
             ]);
-            if ($tmp != null) {
+            if ($tmp !== null) {
                 $html .= $tmp;
             }
         }

--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -16,6 +16,7 @@ namespace BEdita\WebTools\View\Helper;
 use Cake\Core\Configure;
 use Cake\Utility\Inflector;
 use Cake\View\Helper\HtmlHelper as CakeHtmlHelper;
+use Cake\View\View;
 
 /**
  * Html helper.
@@ -23,6 +24,43 @@ use Cake\View\Helper\HtmlHelper as CakeHtmlHelper;
  */
 class HtmlHelper extends CakeHtmlHelper
 {
+
+    /**
+     * Meta data for helper
+     */
+    protected $meta = [
+        'description' => '',
+        'author' => '',
+        'viewport' => '',
+        'msapplication-TileColor' => '',
+        'theme-color' => '',
+        'docType' => '',
+        'project' => [
+            'name' => '',
+            'version' => '',
+        ],
+    ];
+
+    /**
+     * Construct the meta data
+     * Merge data to $this->meta from configure 'Meta', if set
+     * Merge data to $this->meta from $config['meta'], if set
+     *
+     * @param \Cake\View\View $View The View this helper is being attached to.
+     * @param array $config Configuration settings for the helper.
+     */
+    public function __construct(View $View, array $config = [])
+    {
+        if ($meta = Configure::read('Meta')) {
+            $this->meta += $meta;
+        }
+        if (isset($config['meta'])) {
+            $this->meta = $config['meta'] + $this->meta;
+            unset($config['meta']);
+        }
+        parent::__construct($View, $config);
+    }
+
     /**
      * Title for template pages
      * If `_title` view var is set, return it
@@ -55,8 +93,9 @@ class HtmlHelper extends CakeHtmlHelper
      *  - viewport
      *  - msapplication-TileColor
      *  - theme-color
-     *  - css
-     *  - generator
+     *  - docType
+     *  - project.name
+     *  - project.version
      *
      * @param array $data Data for meta: 'description', 'author', 'viewport', 'msapplication-TileColor', 'theme-color', 'docType', 'project' (['name' => '...', 'version' => '...'])
      * @return string
@@ -67,14 +106,12 @@ class HtmlHelper extends CakeHtmlHelper
         $html = '';
 
         // description
-        if (!empty($data['description'])) {
-            $html .= $this->metaDescription($data['description']);
-        }
+        $description = $this->getMetaString($data, 'description', '');
+        $html .= $this->metaDescription($description);
 
         // author
-        if (!empty($data['author'])) {
-            $html .= $this->metaAuthor($data['author']);
-        }
+        $author = $this->getMetaString($data, 'author', '');
+        $html .= $this->metaAuthor($author);
 
         // viewport, msapplication-TileColor, theme-color
         foreach (['viewport', 'msapplication-TileColor', 'theme-color'] as $attribute) {
@@ -87,22 +124,11 @@ class HtmlHelper extends CakeHtmlHelper
         }
 
         // css
-        $docType = '';
-        if (!empty($data['docType'])) {
-            $docType = $data['docType'];
-        } else {
-            $docType = Configure::read('docType');
-            if (empty($docType)) {
-                $docType = 'xhtml-strict';
-            }
-        }
+        $docType = $this->getMetaString($data, 'docType', 'xhtml-strict');
         $html .= $this->metaCss($docType);
 
         // generator
-        $project = [];
-        if (!empty($data['project'])) {
-            $project = $data['project'];
-        }
+        $project = $this->getMetaArray($data, 'project', []);
         $html .= $this->metaGenerator($project);
 
         return $html;
@@ -300,5 +326,45 @@ class HtmlHelper extends CakeHtmlHelper
         }
 
         return $html;
+    }
+
+    /**
+     * Return meta by data and field
+     *
+     * @param array $data The data
+     * @param string $field The field
+     * @param string $defaultVal The default val
+     * @return string
+     */
+    public function getMetaString(array $data, string $field, ?string $defaultVal) : string
+    {
+        if (isset($data[$field])) {
+            return $data[$field];
+        }
+        if (isset($this->meta[$field])) {
+            return $this->meta[$field];
+        }
+
+        return (string)$defaultVal;
+    }
+
+    /**
+     * Return meta by data and field
+     *
+     * @param array $data The data
+     * @param string $field The field
+     * @param array|null $defaultVal The default val
+     * @return string
+     */
+    public function getMetaArray(array $data, string $field, ?array $defaultVal) : array
+    {
+        if (isset($data[$field])) {
+            return $data[$field];
+        }
+        if (isset($this->meta[$field])) {
+            return $this->meta[$field];
+        }
+
+        return (array)$defaultVal;
     }
 }

--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -31,9 +31,6 @@ class HtmlHelper extends CakeHtmlHelper
     protected $metadata = [
         'description' => '',
         'author' => '',
-        'viewport' => '',
-        'msapplication-TileColor' => '',
-        'theme-color' => '',
         'docType' => '',
         'project' => [
             'name' => '',
@@ -90,14 +87,11 @@ class HtmlHelper extends CakeHtmlHelper
      *
      *  - description
      *  - author
-     *  - viewport
-     *  - msapplication-TileColor
-     *  - theme-color
      *  - docType
      *  - project.name
      *  - project.version
      *
-     * @param array $data Data for meta: 'description', 'author', 'viewport', 'msapplication-TileColor', 'theme-color', 'docType', 'project' (['name' => '...', 'version' => '...'])
+     * @param array $data Data for meta: 'description', 'author', 'docType', 'project' (['name' => '...', 'version' => '...'], ...)
      * @return string
      * @see HtmlHelper
      */
@@ -113,16 +107,6 @@ class HtmlHelper extends CakeHtmlHelper
         $author = $this->getMetaString($data, 'author', '');
         $html .= $this->metaAuthor($author);
 
-        // viewport, msapplication-TileColor, theme-color
-        foreach (['viewport', 'msapplication-TileColor', 'theme-color'] as $attribute) {
-            if (!empty($data[$attribute])) {
-                $html .= $this->meta([
-                    'name' => $attribute,
-                    'content' => $data[$attribute],
-                ]);
-            }
-        }
-
         // css
         $docType = $this->getMetaString($data, 'docType', 'xhtml-strict');
         $html .= $this->metaCss($docType);
@@ -130,6 +114,24 @@ class HtmlHelper extends CakeHtmlHelper
         // generator
         $project = $this->getMetaArray($data, 'project', []);
         $html .= $this->metaGenerator($project);
+
+        // other data
+        $otherdata = $data;
+        foreach (['description', 'author', 'docType', 'project'] as $attribute) {
+            if (isset($otherdata[$attribute])) {
+                unset($otherdata[$attribute]);
+            }
+        }
+        if (!empty($otherdata)) {
+            foreach ($otherdata as $attribute) {
+                if (!empty($otherdata[$attribute])) {
+                    $html .= $this->meta([
+                        'name' => $attribute,
+                        'content' => $otherdata[$attribute],
+                    ]);
+                }
+            }
+        }
 
         return $html;
     }

--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -52,7 +52,7 @@ class HtmlHelper extends CakeHtmlHelper
     public function __construct(View $View, array $config = [])
     {
         if ($meta = Configure::read('Meta')) {
-            $this->metadata += $meta;
+            $this->metadata = $meta + $this->metadata;
         }
         if (isset($config['meta'])) {
             $this->metadata = $config['meta'] + $this->metadata;

--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -111,7 +111,7 @@ class HtmlHelper extends CakeHtmlHelper
             return '';
         }
         $html = $this->meta('description', h(strip_tags($description)));
-        if ($html == null) {
+        if ($html === null) {
             $html = '';
         }
 
@@ -133,7 +133,7 @@ class HtmlHelper extends CakeHtmlHelper
             'name' => 'author',
             'content' => h($creator),
         ]);
-        if ($html == null) {
+        if ($html === null) {
             $html = '';
         }
 
@@ -155,7 +155,7 @@ class HtmlHelper extends CakeHtmlHelper
             'http-equiv' => 'Content-Style-Type',
             'content' => 'text/css',
         ]);
-        if ($html == null) {
+        if ($html === null) {
             $html = '';
         }
 
@@ -181,7 +181,7 @@ class HtmlHelper extends CakeHtmlHelper
             'name' => 'generator',
             'content' => trim(sprintf('%s %s', $project['name'], $version)),
         ]);
-        if ($html == null) {
+        if ($html === null) {
             $html = '';
         }
 

--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -116,12 +116,8 @@ class HtmlHelper extends CakeHtmlHelper
         $html .= $this->metaGenerator($project);
 
         // other data
-        $otherdata = $data;
-        foreach (['description', 'author', 'docType', 'project'] as $attribute) {
-            if (isset($otherdata[$attribute])) {
-                unset($otherdata[$attribute]);
-            }
-        }
+        $keys = ['description', 'author', 'docType', 'project'];
+        $otherdata = array_diff_key($data, array_combine($keys, $keys));
         if (!empty($otherdata)) {
             foreach ($otherdata as $attribute) {
                 if (!empty($otherdata[$attribute])) {

--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -28,7 +28,7 @@ class HtmlHelper extends CakeHtmlHelper
     /**
      * Meta data for helper
      */
-    protected $meta = [
+    protected $metadata = [
         'description' => '',
         'author' => '',
         'viewport' => '',
@@ -43,8 +43,8 @@ class HtmlHelper extends CakeHtmlHelper
 
     /**
      * Construct the meta data
-     * Merge data to $this->meta from configure 'Meta', if set
-     * Merge data to $this->meta from $config['meta'], if set
+     * Merge data to $this->metadata from configure 'Meta', if set
+     * Merge data to $this->metadata from $config['meta'], if set
      *
      * @param \Cake\View\View $View The View this helper is being attached to.
      * @param array $config Configuration settings for the helper.
@@ -52,10 +52,10 @@ class HtmlHelper extends CakeHtmlHelper
     public function __construct(View $View, array $config = [])
     {
         if ($meta = Configure::read('Meta')) {
-            $this->meta += $meta;
+            $this->metadata += $meta;
         }
         if (isset($config['meta'])) {
-            $this->meta = $config['meta'] + $this->meta;
+            $this->metadata = $config['meta'] + $this->metadata;
             unset($config['meta']);
         }
         parent::__construct($View, $config);
@@ -162,7 +162,10 @@ class HtmlHelper extends CakeHtmlHelper
     public function metaAuthor(?string $creator) : string
     {
         if (empty($creator)) {
-            return '';
+            $creator = $this->getMetaString([], 'author', '');
+            if (empty($creator)) {
+                return '';
+            }
         }
         $html = $this->meta([
             'name' => 'author',
@@ -184,7 +187,10 @@ class HtmlHelper extends CakeHtmlHelper
     public function metaCss(string $docType) : string
     {
         if ($docType === 'html5') {
-            return '';
+            $docType = $this->getMetaString([], 'docType', '');
+            if (empty($docType)) {
+                return '';
+            }
         }
         $html = $this->meta([
             'http-equiv' => 'Content-Style-Type',
@@ -206,7 +212,10 @@ class HtmlHelper extends CakeHtmlHelper
     public function metaGenerator(array $project) : string
     {
         if (empty($project) || empty($project['name'])) {
-            return '';
+            $project = $this->getMetaArray([], 'project', []);
+            if (empty($project) || empty($project['name'])) {
+                return '';
+            }
         }
         $version = '';
         if (!empty($project['version'])) {
@@ -341,8 +350,8 @@ class HtmlHelper extends CakeHtmlHelper
         if (isset($data[$field])) {
             return $data[$field];
         }
-        if (isset($this->meta[$field])) {
-            return $this->meta[$field];
+        if (isset($this->metadata[$field])) {
+            return $this->metadata[$field];
         }
 
         return (string)$defaultVal;
@@ -361,8 +370,8 @@ class HtmlHelper extends CakeHtmlHelper
         if (isset($data[$field])) {
             return $data[$field];
         }
-        if (isset($this->meta[$field])) {
-            return $this->meta[$field];
+        if (isset($this->metadata[$field])) {
+            return $this->metadata[$field];
         }
 
         return (array)$defaultVal;

--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -354,7 +354,7 @@ class HtmlHelper extends CakeHtmlHelper
      * @param array $data The data
      * @param string $field The field
      * @param array|null $defaultVal The default val
-     * @return string
+     * @return array
      */
     public function getMetaArray(array $data, string $field, ?array $defaultVal) : array
     {

--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -47,9 +47,18 @@ class HtmlHelper extends CakeHtmlHelper
     }
 
     /**
-     * Html meta: description, content, author, css, generator
+     * Html meta
+     * Possible meta data:
      *
-     * @param array $data Data for meta: 'description', 'author', 'docType', 'project', 'theme-color'
+     *  - description
+     *  - author
+     *  - viewport
+     *  - msapplication-TileColor
+     *  - theme-color
+     *  - css
+     *  - generator
+     *
+     * @param array $data Data for meta: 'description', 'author', 'viewport', 'msapplication-TileColor', 'theme-color', 'docType', 'project' (['name' => '...', 'version' => '...'])
      * @return string
      * @see HtmlHelper
      */

--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -211,9 +211,9 @@ class HtmlHelper extends CakeHtmlHelper
      */
     public function metaGenerator(array $project) : string
     {
-        if (empty($project) || empty($project['name'])) {
+        if (empty($project['name'])) {
             $project = $this->getMetaArray([], 'project', []);
-            if (empty($project) || empty($project['name'])) {
+            if (empty($project['name'])) {
                 return '';
             }
         }

--- a/tests/TestCase/View/Helper/HtmlHelperTest.php
+++ b/tests/TestCase/View/Helper/HtmlHelperTest.php
@@ -304,7 +304,7 @@ class HtmlHelperTest extends TestCase
                         'version' => '2.0',
                     ],
                 ],
-                '<meta name="description" content="dummy description"/><meta name="author" content="gustavo"/><meta name="viewport" content="width=device-width, initial-scale=1.0"/><meta name="msapplication-TileColor" content="#009cc7"/><meta name="theme-color" content="#ABC000"/><meta http-equiv="Content-Style-Type" content="text/css"/><meta name="generator" content="my dummy project 2.0"/>',
+                '<meta name="description" content="dummy description"/><meta name="author" content="gustavo"/><meta http-equiv="Content-Style-Type" content="text/css"/><meta name="generator" content="my dummy project 2.0"/>',
             ],
         ];
     }

--- a/tests/TestCase/View/Helper/HtmlHelperTest.php
+++ b/tests/TestCase/View/Helper/HtmlHelperTest.php
@@ -405,14 +405,15 @@ class HtmlHelperTest extends TestCase
     }
 
     /**
-     * Data provider for `testGetMetaString` test case.
+     * Data provider for `testGetMeta` test case.
      *
      * @return array
      */
-    public function getMetaStringProvider() : array
+    public function getMetaProvider() : array
     {
         return [
-            'empty data default null' => [
+            // string
+            '(string) empty data default null' => [
                 [], // config
                 [], // data
                 'something', // field
@@ -433,42 +434,13 @@ class HtmlHelperTest extends TestCase
                 null, // default val
                 'whatever from data', // expected
             ],
-        ];
-    }
-
-    /**
-     * Test `getMeta` method
-     *
-     * @dataProvider getMetaStringProvider()
-     * @covers ::getMetaString()
-     * @covers ::__construct()
-     * @param array $data The data
-     * @param array $string The field for data
-     * @param string|null $defaultVal The default value
-     * @param string $expected The expected meta string
-     * @return void
-     */
-    public function testGetMetaString(array $config, array $data, string $field, ?string $defaultVal, string $expected) : void
-    {
-        $this->Html = new HtmlHelper(new View(), $config);
-        $actual = $this->Html->getMetaString($data, $field, $defaultVal);
-        static::assertEquals($expected, $actual);
-    }
-
-    /**
-     * Data provider for `testGetMetaArray` test case.
-     *
-     * @return array
-     */
-    public function getMetaArrayProvider() : array
-    {
-        return [
-            'empty data default null' => [
+            // array
+            '(array) empty data default null' => [
                 [], // config
                 [], // data
                 'something', // field
                 null, // default val
-                [], // expected
+                null, // expected
             ],
             'project from config' => [
                 ['meta' => ['project' => ['name' => 'gustavo', 'version' => '3.0']]], // config
@@ -488,22 +460,22 @@ class HtmlHelperTest extends TestCase
     }
 
     /**
-     * Test `getMetaArray` method
+     * Test `getMeta` method
      *
-     * @dataProvider getMetaArrayProvider()
-     * @covers ::getMetaArray()
-     * @covers ::__construct()
-     * @param array $config The meta config
+     * @dataProvider getMetaProvider()
+     * @covers ::getMeta()
+     * @covers ::initialize()
+     * @param array $config The configuration
      * @param array $data The data
      * @param array $string The field for data
-     * @param array|null $defaultVal The default value
-     * @param array $expected The expected meta array
+     * @param array|string|null $defaultVal The default val
+     * @param string|array|null $expected The expected meta
      * @return void
      */
-    public function testGetMetaArray(array $config, array $data, string $field, ?array $defaultVal, array $expected) : void
+    public function testGetMeta(array $config, array $data, string $field, $defaultVal = null, $expected = null) : void
     {
         $this->Html = new HtmlHelper(new View(), $config);
-        $actual = $this->Html->getMetaArray($data, $field, $defaultVal);
+        $actual = $this->Html->getMeta($data, $field, $defaultVal);
         static::assertEquals($expected, $actual);
     }
 }

--- a/tests/TestCase/View/Helper/HtmlHelperTest.php
+++ b/tests/TestCase/View/Helper/HtmlHelperTest.php
@@ -403,4 +403,107 @@ class HtmlHelperTest extends TestCase
         $actual = $this->Html->metaTwitter($data);
         static::assertEquals($expected, $actual);
     }
+
+    /**
+     * Data provider for `testGetMetaString` test case.
+     *
+     * @return array
+     */
+    public function getMetaStringProvider() : array
+    {
+        return [
+            'empty data default null' => [
+                [], // config
+                [], // data
+                'something', // field
+                null, // default val
+                '', // expected
+            ],
+            'description from config' => [
+                ['meta' => ['description' => 'whatever']], // config
+                [], // data
+                'description', // field
+                null, // default val
+                'whatever', // expected
+            ],
+            'description from data' => [
+                ['meta' => ['description' => 'whatever']], // config
+                ['description' => 'whatever from data'], // data
+                'description', // field
+                null, // default val
+                'whatever from data', // expected
+            ],
+        ];
+    }
+
+    /**
+     * Test `getMeta` method
+     *
+     * @dataProvider getMetaStringProvider()
+     * @covers ::getMetaString()
+     * @covers ::__construct()
+     * @param array $data The data
+     * @param array $string The field for data
+     * @param string|null $defaultVal The default value
+     * @param string $expected The expected meta string
+     * @return void
+     */
+    public function testGetMetaString(array $config, array $data, string $field, ?string $defaultVal, string $expected) : void
+    {
+        $this->Html = new HtmlHelper(new View(), $config);
+        $actual = $this->Html->getMetaString($data, $field, $defaultVal);
+        static::assertEquals($expected, $actual);
+    }
+
+    /**
+     * Data provider for `testGetMetaArray` test case.
+     *
+     * @return array
+     */
+    public function getMetaArrayProvider() : array
+    {
+        return [
+            'empty data default null' => [
+                [], // config
+                [], // data
+                'something', // field
+                null, // default val
+                [], // expected
+            ],
+            'project from config' => [
+                ['meta' => ['project' => ['name' => 'gustavo', 'version' => '3.0']]], // config
+                [], // data
+                'project', // field
+                null, // default val
+                ['name' => 'gustavo', 'version' => '3.0'], // expected
+            ],
+            'project from data' => [
+                ['meta' => ['project' => ['name' => 'gustavo', 'version' => '3.0']]], // config
+                ['project' => ['name' => 'gustavo', 'version' => '4.0']], // data
+                'project', // field
+                null, // default val
+                ['name' => 'gustavo', 'version' => '4.0'], // expected
+            ],
+        ];
+    }
+
+    /**
+     * Test `getMetaArray` method
+     *
+     * @dataProvider getMetaArrayProvider()
+     * @covers ::getMetaArray()
+     * @covers ::__construct()
+     * @param array $config The meta config
+     * @param array $data The data
+     * @param array $string The field for data
+     * @param array|null $defaultVal The default value
+     * @param array $expected The expected meta array
+     * @return void
+     */
+    public function testGetMetaArray(array $config, array $data, string $field, ?array $defaultVal, array $expected) : void
+    {
+        $this->Html = new HtmlHelper(new View(), $config);
+        $actual = $this->Html->getMetaArray($data, $field, $defaultVal);
+        static::assertEquals($expected, $actual);
+    }
 }

--- a/tests/TestCase/View/Helper/HtmlHelperTest.php
+++ b/tests/TestCase/View/Helper/HtmlHelperTest.php
@@ -111,4 +111,296 @@ class HtmlHelperTest extends TestCase
         $actual = $this->Html->title();
         static::assertEquals($expected, $actual);
     }
+
+    /**
+     * Data provider for `testMetaDescription` test case.
+     *
+     * @return array
+     */
+    public function metaDescriptionProvider() : array
+    {
+        return [
+            'null description' => [
+                null,
+                '',
+            ],
+            'empty description' => [
+                '',
+                '',
+            ],
+            'dummy description' => [
+                'dummy',
+                '<meta name="description" content="dummy"/>',
+            ],
+            'description with special chars and tags' => [
+                'dummy <> & dummy',
+                '<meta name="description" content="dummy  &amp;amp; dummy"/>',
+            ],
+        ];
+    }
+
+    /**
+     * Test `metaDescription` method
+     *
+     * @dataProvider metaDescriptionProvider()
+     * @covers ::metaDescription()
+     * @param string|null $description The description
+     * @param string $expected The expected meta description
+     * @return void
+     */
+    public function testMetaDescription(?string $description, string $expected) : void
+    {
+        $actual = $this->Html->metaDescription($description);
+        static::assertEquals($expected, $actual);
+    }
+
+    /**
+     * Data provider for `testMetaAuthor` test case.
+     *
+     * @return array
+     */
+    public function metaAuthorProvider() : array
+    {
+        return [
+            'null creator' => [
+                null,
+                '',
+            ],
+            'empty creator' => [
+                '',
+                '',
+            ],
+            'dummy creator' => [
+                'dummy',
+                '<meta name="author" content="dummy"/>',
+            ],
+            'creator with special chars and tags' => [
+                'dummy <> & dummy',
+                '<meta name="author" content="dummy &amp;lt;&amp;gt; &amp;amp; dummy"/>',
+            ],
+        ];
+    }
+
+    /**
+     * Test `metaAuthor` method
+     *
+     * @dataProvider metaAuthorProvider()
+     * @covers ::metaAuthor()
+     * @param string|null $creator The content creator
+     * @param string $expected The expected meta content author
+     * @return void
+     */
+    public function testMetaAuthor(?string $creator, string $expected) : void
+    {
+        $actual = $this->Html->metaAuthor($creator);
+        static::assertEquals($expected, $actual);
+    }
+
+    /**
+     * Data provider for `testMetaCss` test case.
+     *
+     * @return array
+     */
+    public function metaCssProvider() : array
+    {
+        return [
+            'empty docType' => [
+                '',
+                '<meta http-equiv="Content-Style-Type" content="text/css"/>',
+            ],
+            'html5 docType' => [
+                'html5',
+                '',
+            ],
+        ];
+    }
+
+    /**
+     * Test `metaCss` method
+     *
+     * @dataProvider metaCssProvider()
+     * @covers ::metaCss()
+     * @param string $docType The doc type
+     * @param string $expected The expected meta content author
+     * @return void
+     */
+    public function testMetaCss(string $docType, string $expected) : void
+    {
+        $actual = $this->Html->metaCss($docType);
+        static::assertEquals($expected, $actual);
+    }
+
+    /**
+     * Data provider for `testMetaGenerator` test case.
+     *
+     * @return array
+     */
+    public function metaGeneratorProvider() : array
+    {
+        return [
+            'empty project and version' => [
+                [],
+                '',
+            ],
+            'empty project and version' => [
+                [
+                    'name' => '',
+                    'version' => '',
+                ],
+                '',
+            ],
+            'only project' => [
+                [
+                    'name' => 'Dummy',
+                ],
+                '<meta name="generator" content="Dummy"/>',
+            ],
+            'project and version' => [
+                [
+                    'name' => 'Dummy',
+                    'version' => '1.0',
+                ],
+                '<meta name="generator" content="Dummy 1.0"/>',
+            ],
+        ];
+    }
+
+    /**
+     * Test `metaGenerator` method
+     *
+     * @dataProvider metaGeneratorProvider()
+     * @covers ::metaGenerator()
+     * @param array $project The project data ('name', 'version')
+     * @param string $expected The expected meta content author
+     * @return void
+     */
+    public function testMetaGenerator(array $project, string $expected) : void
+    {
+        $actual = $this->Html->metaGenerator($project);
+        static::assertEquals($expected, $actual);
+    }
+
+    /**
+     * Data provider for `testMetaAll` test case.
+     *
+     * @return array
+     */
+    public function metaAllProvider() : array
+    {
+        return [
+            'empty data' => [
+                [],
+                '<meta http-equiv="Content-Style-Type" content="text/css"/>',
+            ],
+            'full data' => [
+                [
+                    'viewport' => 'width=device-width, initial-scale=1.0',
+                    'msapplication-TileColor' => '#009cc7',
+                    'theme-color' => '#ABC000',
+                    'description' => 'dummy description',
+                    'author' => 'gustavo',
+                    'project' => [
+                        'name' => 'my dummy project',
+                        'version' => '2.0',
+                    ],
+                ],
+                '<meta name="description" content="dummy description"/><meta name="author" content="gustavo"/><meta name="viewport" content="width=device-width, initial-scale=1.0"/><meta name="msapplication-TileColor" content="#009cc7"/><meta name="theme-color" content="#ABC000"/><meta http-equiv="Content-Style-Type" content="text/css"/><meta name="generator" content="my dummy project 2.0"/>',
+            ],
+        ];
+    }
+
+    /**
+     * Test `metaAll` method
+     *
+     * @dataProvider metaAllProvider()
+     * @covers ::metaAll()
+     * @param array $data The data for meta
+     * @param string $expected The expected meta html
+     * @return void
+     */
+    public function testMetaAll(array $data, string $expected) : void
+    {
+        $actual = $this->Html->metaAll($data);
+        static::assertEquals($expected, $actual);
+    }
+
+    /**
+     * Data provider for `testMetaOpenGraph` test case.
+     *
+     * @return array
+     */
+    public function metaOpenGraphProvider() : array
+    {
+        return [
+            'empty data' => [
+                [],
+                '',
+            ],
+            'url + title + description + image' => [
+                [
+                    'url' => 'https://example.com',
+                    'title' => 'dummy',
+                    'description' => 'a dummy data for test',
+                    'image' => 'an image',
+                ],
+                '<meta property="og:url" content="https://example.com"/><meta property="og:title" content="dummy"/><meta property="og:description" content="a dummy data for test"/><meta property="og:image" content="an image"/>',
+            ],
+        ];
+    }
+
+    /**
+     * Test `metaOpenGraph` method
+     *
+     * @dataProvider metaOpenGraphProvider()
+     * @covers ::metaOpenGraph()
+     * @param array $data The data for meta
+     * @param string $expected The expected meta html
+     * @return void
+     */
+    public function testMetaOpenGraph(array $data, string $expected) : void
+    {
+        $actual = $this->Html->metaOpenGraph($data);
+        static::assertEquals($expected, $actual);
+    }
+
+    /**
+     * Data provider for `testMetaTwitter` test case.
+     *
+     * @return array
+     */
+    public function metaTwitterProvider() : array
+    {
+        return [
+            'empty data' => [
+                [],
+                '',
+            ],
+            'card + site + creator + title + description + image' => [
+                [
+                    'card' => 'whatever',
+                    'site' => 'example.com',
+                    'creator' => 'gustavo',
+                    'title' => 'dummy',
+                    'description' => 'a dummy data for test',
+                    'image' => 'an image',
+                ],
+                '<meta property="twitter:card" content="whatever"/><meta property="twitter:site" content="example.com"/><meta property="twitter:creator" content="gustavo"/><meta property="twitter:title" content="dummy"/><meta property="twitter:description" content="a dummy data for test"/><meta property="twitter:image" content="an image"/>',
+            ],
+        ];
+    }
+
+    /**
+     * Test `metaTwitter` method
+     *
+     * @dataProvider metaTwitterProvider()
+     * @covers ::metaTwitter()
+     * @param array $data The data for meta
+     * @param string $expected The expected meta html
+     * @return void
+     */
+    public function testMetaTwitter(array $data, string $expected) : void
+    {
+        $actual = $this->Html->metaTwitter($data);
+        static::assertEquals($expected, $actual);
+    }
 }


### PR DESCRIPTION
This provides #6 
New methods available in `BEdita\WebTools\View\Helper\HtmlHelper`:

```
public function metaAll(array $data) : string
public function metaDescription($description) : string
public function metaAuthor(?string $creator) : string
public function metaCss(string $docType) : string
public function metaOpenGraph(array $data) : string
public function metaTwitter(array $data) : string
[...]
public function getMeta(array $data, string $field, $defaultVal = null)
```

`BEdita\WebTools\View\Helper\HtmlHelper` initialize uses meta data (if set) from:

 - `Configure::read('Meta')` // override defaults
 - `$config['meta']` // override defaults and `Meta` from config

Examples of usage:

// 1. using configuration `Meta`
```
Configure::write('Meta', ['author' => 'gustavo']);
[...]
// in twig template file
{{ Html.metaAuthor() }}
```

// 2. using `$config` in constructor
```
$this->Html = new HtmlHelper(new View(), ['meta' => ['author' => 'gustavo']]);
[...]
// in twig template file
{{ Html.metaAuthor() }}
```
// 3. bypass config
```
// in twig template file
{{ Html.metaAuthor('gustavo') }}
```

An example of `metaAll`:
```
{{ Html.metaAll([
    'viewport' => 'width=device-width, initial-scale=1.0',
    'msapplication-TileColor' => '#009cc7',
    'theme-color' => '#ABC000',
    'description' => 'My dummy website',
    'author' => 'gustavo',
    'project' => [
        'name' => 'My dummy project',
        'version' => '2.0',
    ]
]) }}
```
or
```
Configure::write('Meta', [
    'viewport' => 'width=device-width, initial-scale=1.0',
    'msapplication-TileColor' => '#009cc7',
    'theme-color' => '#ABC000',
    'description' => 'My dummy website',
    'author' => 'gustavo',
    'project' => [
        'name' => 'My dummy project',
        'version' => '2.0',
    ]
]);
[...]
// in twig template file
{{ Html.metaAll([
    'description' => 'My dummy website - page X',
]) }}
```