### PR TITLE
Handle assets revisions in `Html` helper

### DIFF
--- a/src/Utility/AssetsRevisions.php
+++ b/src/Utility/AssetsRevisions.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2020 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\WebTools\Utility;
+
+/**
+ * Utility class to handle asset names with revisions/signatures.
+ *
+ * Rev manifest file default path is `config/rev-manifest.json`
+ * Other file paths may be used via `$config['manifestPath']`
+ */
+class AssetsRevisions
+{
+    /**
+     * Array having asset names as keys and revved asset names as values
+     *
+     * @var array
+     */
+    static protected $assets = null;
+
+    /**
+     * Load manifest
+     *
+     * @param array $config
+     * @return void
+     */
+    public static function loadManifest(string $path = null): void
+    {
+        static::$assets = [];
+        if (empty($path)) {
+            $path = CONFIG . 'rev-manifest.json';
+        }
+        if (file_exists($path)) {
+            static::$assets = (array)json_decode(file_get_contents($path), true);
+        }
+    }
+
+    /**
+     * Retrieve `revved` asset name if found in manifest or return canonical asset name otherwise
+     *
+     * @param string $name Canonical asset name (un-revved)
+     * @param string $extension Optional extension to use to search asset, like '.js' or '.css'
+     * @return string
+     */
+    public static function get(string $name, string $extension = null): string
+    {
+        if (static::$assets === null) {
+            static::loadManifest();
+        }
+
+        if (!empty(static::$assets[$name])) {
+            return (string)static::$assets[$name];
+        }
+        if (!empty($extension) && !empty(static::$assets[$name . $extension])) {
+            return (string)static::$assets[$name . $extension];
+         }
+
+        return $name;
+    }
+
+    /**
+     * Retrieve `revved` asset names array via ::get() call
+     *
+     * @param array $names Canonical asset names (un-revved)
+     * @param string $extension Optional extension to use to search asset, like '.js' or '.css'
+     * @return array
+     */
+    public static function getMulti(array $names, string $extension = null): array
+    {
+        foreach ($names as $k => $val) {
+            $names[$k] = static::get($val, $extension);
+        }
+
+        return $names;
+    }
+}

--- a/src/Utility/AssetsRevisions.php
+++ b/src/Utility/AssetsRevisions.php
@@ -17,7 +17,7 @@ namespace BEdita\WebTools\Utility;
  * Utility class to handle asset names with revisions/signatures.
  *
  * Rev manifest file default path is `config/rev-manifest.json`
- * Other file paths may be used via `$config['manifestPath']`
+ * Other file paths may be used via `loadManifest()`
  */
 class AssetsRevisions
 {
@@ -26,12 +26,12 @@ class AssetsRevisions
      *
      * @var array
      */
-    static protected $assets = null;
+    protected static $assets = null;
 
     /**
-     * Load manifest
+     * Load revision manifest JSON.
      *
-     * @param array $config
+     * @param array $path Manifest file path
      * @return void
      */
     public static function loadManifest(string $path = null): void
@@ -63,7 +63,7 @@ class AssetsRevisions
         }
         if (!empty($extension) && !empty(static::$assets[$name . $extension])) {
             return (string)static::$assets[$name . $extension];
-         }
+        }
 
         return $name;
     }

--- a/src/View/Helper/AssetHelper.php
+++ b/src/View/Helper/AssetHelper.php
@@ -13,49 +13,25 @@
 
 namespace BEdita\WebTools\View\Helper;
 
-use Cake\Utility\Hash;
+use BEdita\WebTools\Utility\AssetsRevisions;
 use Cake\View\Helper;
 
 /**
  * Asset Helper to handle asset names with signatures.
  *
- * Rev manifest file default path is `config/rev-manifest.json`
- * Other file paths may be used via `$config['manufestPath']`
+ * @see AssetsRevisions for details
  */
 class AssetHelper extends Helper
 {
-    /**
-     * Array having asset names as keys and revved asset names as values
-     *
-     * @var array
-     */
-    protected $assets = [];
-
-    /**
-     * {@inheritDoc}
-     */
-    public function initialize(array $config): void
-    {
-        $manifestPath = Hash::get($config, 'manifestPath', CONFIG . 'rev-manifest.json');
-        if (!file_exists($manifestPath)) {
-            return;
-        }
-
-        $this->assets = json_decode(file_get_contents($manifestPath), true);
-    }
-
     /**
      * Retrieve `revved` asset name if found in manifest or return canonical asset name otherwise
      *
      * @param string $name Canonical asset name (un-revved)
      * @return string
+     * @deprecated Deprecated since 1.3.0 Use `AssetsRevisions::get` or `Html` helper methods `script` or `css` directly.
      */
     public function get(string $name): string
     {
-        if (!empty($this->assets[$name])) {
-            $name = (string)$this->assets[$name];
-        }
-
-        return $name;
+        return AssetsRevisions::get($name);
     }
 }

--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -13,6 +13,7 @@
 
 namespace BEdita\WebTools\View\Helper;
 
+use BEdita\WebTools\Utility\AssetsRevisions;
 use Cake\Core\Configure;
 use Cake\Utility\Hash;
 use Cake\Utility\Inflector;
@@ -349,5 +350,37 @@ class HtmlHelper extends CakeHtmlHelper
         $meta = $data + $this->metadata;
 
         return Hash::get($meta, $field, $defaultVal);
+    }
+
+    /**
+     * Use `AssetsRevisions` class to load revisioned assets.
+     *
+     * {@inheritDoc}
+     */
+    public function script($url, array $options = []): ?string
+    {
+        if (is_array($url)) {
+            $url = AssetsRevisions::getMulti($url, '.js');
+        } else {
+            $url = AssetsRevisions::get($url, '.js');
+        }
+
+        return parent::script($url, $options);
+    }
+
+    /**
+     * Use `AssetsRevisions` class to load revisioned assets.
+     *
+     * {@inheritDoc}
+     */
+    public function css($url, array $options = []): ?string
+    {
+        if (is_array($url)) {
+            $url = AssetsRevisions::getMulti($url, '.css');
+        } else {
+            $url = AssetsRevisions::get($url, '.css');
+        }
+
+        return parent::css($url, $options);
     }
 }

--- a/tests/TestCase/Utility/AssetsRevisionsTest.php
+++ b/tests/TestCase/Utility/AssetsRevisionsTest.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2019 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+namespace BEdita\WebTools\Test\TestCase\View\Helper;
+
+use BEdita\WebTools\Utility\AssetsRevisions;
+use Cake\TestSuite\TestCase;
+
+/**
+ * {@see \BEdita\WebTools\Utility\AssetsRevisions} Test Case
+ *
+ * @coversDefaultClass \BEdita\WebTools\Utility\AssetsRevisions
+ */
+class AssetsRevisionsTest extends TestCase
+{
+    /**
+     * Data provider for `testGet` test case.
+     *
+     * @return array
+     */
+    public function getProvider(): array
+    {
+        return [
+            'simple' => [
+                'script-622a2cc4f5.js',
+                'script.js',
+            ],
+            'not found' => [
+                'functions.js',
+                'functions.js',
+            ],
+            'extension' => [
+                'style-b7c54b4c5a.css',
+                'style',
+                '.css',
+            ],
+            'extension missing' => [
+                'script',
+                'script',
+                '.css'
+            ],
+        ];
+    }
+
+    /**
+     * Test `get` method
+     *
+     * @dataProvider getProvider()
+     * @covers ::get()
+     *
+     * @param string $expected The expected result
+     * @param string $name The asset name
+     * @param string $extension The asset extension
+     * @return void
+     */
+    public function testGet(string $expected, string $name, string $extension = null): void
+    {
+        $result = AssetsRevisions::get($name, $extension);
+        static::assertEquals($expected, $result);
+    }
+
+    /**
+     * Test `getMulti` method
+     *
+     * @covers ::getMulti()
+     * @return void
+     */
+    public function testGetMulti(): void
+    {
+        $expected = [
+            'script-622a2cc4f5.js',
+            'about',
+        ];
+
+        $result = AssetsRevisions::getMulti(['script', 'about'], '.js');
+        static::assertEquals($expected, $result);
+    }
+
+    /**
+     * Test `loadManifest`
+     *
+     * @covers ::loadManifest()
+     * @return void
+     */
+    public function testLoadManifest()
+    {
+        // use different path
+        $path = '/some/path/manifest.json';
+        AssetsRevisions::loadManifest($path);
+
+        $result = AssetsRevisions::get('script.js');
+        static::assertEquals('script.js', $result);
+
+        // reload default
+        AssetsRevisions::loadManifest();
+        $result = AssetsRevisions::get('script.js');
+        static::assertEquals('script-622a2cc4f5.js', $result);
+    }
+}

--- a/tests/TestCase/Utility/AssetsRevisionsTest.php
+++ b/tests/TestCase/Utility/AssetsRevisionsTest.php
@@ -46,7 +46,7 @@ class AssetsRevisionsTest extends TestCase
             'extension missing' => [
                 'script',
                 'script',
-                '.css'
+                '.css',
             ],
         ];
     }

--- a/tests/TestCase/View/Helper/AssetHelperTest.php
+++ b/tests/TestCase/View/Helper/AssetHelperTest.php
@@ -12,6 +12,7 @@
  */
 namespace BEdita\WebTools\Test\TestCase\View\Helper;
 
+use BEdita\WebTools\Utility\AssetsRevisions;
 use BEdita\WebTools\View\Helper\AssetHelper;
 use Cake\TestSuite\TestCase;
 use Cake\View\View;
@@ -24,47 +25,16 @@ use Cake\View\View;
 class AssetHelperTest extends TestCase
 {
     /**
-     * Data provider for `testGet` test case.
-     *
-     * @return array
-     */
-    public function getProvider(): array
-    {
-        return [
-            'simple' => [
-                'script-h74fba9b9e.js',
-                'script.js',
-            ],
-            'not found' => [
-                'functions.js',
-                'functions.js',
-            ],
-            'custom path' => [
-                'script.js',
-                'script.js',
-                [
-                    'manifestPath' => ROOT . 'mymanifestpath',
-                ],
-            ],
-        ];
-    }
-
-    /**
      * Test `get` method
      *
-     * @dataProvider getProvider()
      * @covers ::get()
-     * @covers ::initialize()
      *
-     * @param string $expected The expected result
-     * @param string $name The asset name
-     * @param string $config The helper config
      * @return void
      */
-    public function testGet(string $expected, string $name, array $config = []): void
+    public function testGet(): void
     {
-        $Asset = new AssetHelper(new View(), $config);
-        $result = $Asset->get($name);
-        static::assertEquals($expected, $result);
+        $Asset = new AssetHelper(new View());
+        $result = $Asset->get('script.js');
+        static::assertEquals('script-622a2cc4f5.js', $result);
     }
 }

--- a/tests/TestCase/View/Helper/HtmlHelperTest.php
+++ b/tests/TestCase/View/Helper/HtmlHelperTest.php
@@ -502,7 +502,7 @@ class HtmlHelperTest extends TestCase
                 'functions.js',
             ],
             'multi' => [
-                '<script src="/script-622a2cc4f5.js"></script>'.
+                '<script src="/script-622a2cc4f5.js"></script>' .
                 "\n\t" .
                 '<script src="/page-1x4f92530c.js"></script>',
                 ['script', 'page'],
@@ -543,13 +543,14 @@ class HtmlHelperTest extends TestCase
                 'home.css',
             ],
             'multi' => [
-                '<link rel="stylesheet" href="/style-b7c54b4c5a.css"/>'.
+                '<link rel="stylesheet" href="/style-b7c54b4c5a.css"/>' .
                 "\n\t" .
                 '<link rel="stylesheet" href="/page.css"/>',
                 ['style', 'page'],
             ],
         ];
     }
+
     /**
      * Test `script` method
      *

--- a/tests/TestCase/View/Helper/HtmlHelperTest.php
+++ b/tests/TestCase/View/Helper/HtmlHelperTest.php
@@ -552,7 +552,7 @@ class HtmlHelperTest extends TestCase
     }
 
     /**
-     * Test `script` method
+     * Test `css` method
      *
      * @dataProvider cssProvider()
      * @covers ::css()

--- a/tests/TestCase/View/Helper/HtmlHelperTest.php
+++ b/tests/TestCase/View/Helper/HtmlHelperTest.php
@@ -484,4 +484,85 @@ class HtmlHelperTest extends TestCase
         $actual = $this->Html->getMeta($data, $field, $defaultVal);
         static::assertEquals($expected, $actual);
     }
+
+    /**
+     * Data provider for `testScript` test case.
+     *
+     * @return array
+     */
+    public function scriptProvider(): array
+    {
+        return [
+            'simple' => [
+                '<script src="/script-622a2cc4f5.js"></script>',
+                'script',
+            ],
+            'not found' => [
+                '<script src="/functions.js"></script>',
+                'functions.js',
+            ],
+            'multi' => [
+                '<script src="/script-622a2cc4f5.js"></script>'.
+                "\n\t" .
+                '<script src="/page-1x4f92530c.js"></script>',
+                ['script', 'page'],
+            ],
+        ];
+    }
+
+    /**
+     * Test `script` method
+     *
+     * @dataProvider scriptProvider()
+     * @covers ::script()
+     *
+     * @param string|string[] $expected The expected result
+     * @param string|string[] $name The asset name
+     * @return void
+     */
+    public function testScript($expected, $name): void
+    {
+        $result = $this->Html->script($name);
+        static::assertEquals($expected, trim($result));
+    }
+
+    /**
+     * Data provider for `testCss` test case.
+     *
+     * @return array
+     */
+    public function cssProvider(): array
+    {
+        return [
+            'simple' => [
+                '<link rel="stylesheet" href="/style-b7c54b4c5a.css"/>',
+                'style',
+            ],
+            'not found' => [
+                '<link rel="stylesheet" href="/home.css"/>',
+                'home.css',
+            ],
+            'multi' => [
+                '<link rel="stylesheet" href="/style-b7c54b4c5a.css"/>'.
+                "\n\t" .
+                '<link rel="stylesheet" href="/page.css"/>',
+                ['style', 'page'],
+            ],
+        ];
+    }
+    /**
+     * Test `script` method
+     *
+     * @dataProvider cssProvider()
+     * @covers ::css()
+     *
+     * @param string|string[] $expected The expected result
+     * @param string|string[] $name The asset name
+     * @return void
+     */
+    public function testCss($expected, $name): void
+    {
+        $result = $this->Html->css($name);
+        static::assertEquals($expected, trim($result));
+    }
 }

--- a/tests/test_app/config/rev-manifest.json
+++ b/tests/test_app/config/rev-manifest.json
@@ -1,4 +1,5 @@
 {
-  "script.js": "script-h74fba9b9e.js",
-  "style.css": "style-f544b7c5c1.css"
+    "script.js": "script-622a2cc4f5.js",
+    "page.js": "page-1x4f92530c.js",
+    "style.css": "style-b7c54b4c5a.css"
 }


### PR DESCRIPTION
In this PR:

* `AssetsRevisions` utility class to handle revisions mapping
* `Html::script()` and `Html::css()` call `AssetsRevisions` method in order to find any available revisioned asset, then parent method is invoked
