### PR TITLE
Assets strategies loader

### DIFF
--- a/src/Utility/Asset/AssetStrategy.php
+++ b/src/Utility/Asset/AssetStrategy.php
@@ -1,0 +1,76 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2020 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+namespace BEdita\WebTools\Utility\Asset;
+
+use Cake\Core\InstanceConfigTrait;
+
+/**
+ * Abstract base class for asset strategies.
+ * Every asset strategy should extend this class or implements `AssetStrategyInterface`
+ */
+abstract class AssetStrategy implements AssetStrategyInterface
+{
+    use InstanceConfigTrait;
+
+    /**
+     * Default configuration.
+     *
+     * - `manifestPath` is the file path used as manifest for assets
+     *
+     * @var array
+     */
+    protected $_defaultConfig = [
+        'manifestPath' => '',
+    ];
+
+    /**
+     * The assets map loaded.
+     *
+     * @var array
+     */
+    protected $assets = [];
+
+    /**
+     * Initialize an asset strategy instance. Called after the constructor.
+     *
+     * - write conf
+     * - load assets
+     *
+     * @param array $config The configuration for the asset strategy
+     */
+    public function __construct(array $config = [])
+    {
+        $this->setConfig($config);
+        $this->loadAssets();
+    }
+
+    /**
+     * Load assets map.
+     * If no map path is passed then it uses the configured one.
+     *
+     * @param string|null $manifestPath The optional file path to use
+     * @return void
+     */
+    public function loadAssets(?string $manifestPath = null): void
+    {
+        $this->assets = [];
+        if (empty($manifestPath)) {
+            $manifestPath = $this->getConfig('manifestPath');
+        }
+        if (file_exists($manifestPath)) {
+            $this->assets = (array)json_decode(file_get_contents($manifestPath), true);
+        }
+    }
+}

--- a/src/Utility/Asset/AssetStrategyInterface.php
+++ b/src/Utility/Asset/AssetStrategyInterface.php
@@ -1,0 +1,38 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2020 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+namespace BEdita\WebTools\Utility\Asset;
+
+/**
+ * Interface that describe an asset strategy.
+ */
+interface AssetStrategyInterface
+{
+    /**
+     * Retrieve the asset corresponding to the name passed.
+     *
+     * @param string $name The name used to looking for the asset
+     * @param string|null $extension Optional asset extension as 'js' or 'css'
+     * @return string|array
+     */
+    public function get(string $name, ?string $extension = null);
+
+    /**
+     * Load assets map optionally using a file path.
+     *
+     * @param string|null $path The optional file path
+     * @return void
+     */
+    public function loadAssets(?string $path = null): void;
+}

--- a/src/Utility/Asset/Strategy/EntrypointsStrategy.php
+++ b/src/Utility/Asset/Strategy/EntrypointsStrategy.php
@@ -1,17 +1,17 @@
 <?php
 declare(strict_types=1);
 
-/**
- * BEdita, API-first content management framework
- * Copyright 2020 ChannelWeb Srl, Chialab Srl
- *
- * This file is part of BEdita: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
- */
+ /**
+  * BEdita, API-first content management framework
+  * Copyright 2020 ChannelWeb Srl, Chialab Srl
+  *
+  * This file is part of BEdita: you can redistribute it and/or modify
+  * it under the terms of the GNU Lesser General Public License as published
+  * by the Free Software Foundation, either version 3 of the License, or
+  * (at your option) any later version.
+  *
+  * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+  */
  namespace BEdita\WebTools\Utility\Asset\Strategy;
 
 use BEdita\WebTools\Utility\Asset\AssetStrategy;

--- a/src/Utility/Asset/Strategy/EntrypointsStrategy.php
+++ b/src/Utility/Asset/Strategy/EntrypointsStrategy.php
@@ -1,0 +1,69 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2020 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+ namespace BEdita\WebTools\Utility\Asset\Strategy;
+
+use BEdita\WebTools\Utility\Asset\AssetStrategy;
+use Cake\Utility\Hash;
+
+/**
+ * Entrypoints asset strategy.
+ * This strategy is based on map produced by Webpack Encore and expects a JSON assets map like
+ *
+ * ```
+ * {
+ *     "entrypoints": {
+ *         "app": {
+ *             "js": [
+ *                 "/build/runtime.f011bcb1.js",
+ *                 "/build/0.54651780.js",
+ *                 "/build/app.82269f26.js"
+ *             ]
+ *         },
+ *         "style": {
+ *             "js": [
+ *                 "/build/runtime.f011bcb1.js"
+ *             ],
+ *             "css": [
+ *                 "/build/style.12c5249c.css"
+ *             ]
+ *         }
+ *     }
+ * }
+ * ```
+ *
+ * @see https://symfony.com/doc/current/frontend.html
+ */
+class EntrypointsStrategy extends AssetStrategy
+{
+    /**
+     * {@inheritDoc}
+     */
+    protected $_defaultConfig = [
+        'manifestPath' => WWW_ROOT . 'build' . DS . 'entrypoints.json',
+    ];
+
+    /**
+     * {@inheritDoc}
+     */
+    public function get(string $name, ?string $extension = null)
+    {
+        $path = sprintf('entrypoints.%s', $name);
+        if (!empty($extension)) {
+            $path .= sprintf('.%s', $extension);
+        }
+
+        return Hash::get($this->assets, $path);
+    }
+}

--- a/src/Utility/Asset/Strategy/RevManifestStrategy.php
+++ b/src/Utility/Asset/Strategy/RevManifestStrategy.php
@@ -1,0 +1,54 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2020 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+namespace BEdita\WebTools\Utility\Asset\Strategy;
+
+use BEdita\WebTools\Utility\Asset\AssetStrategy;
+
+/**
+ * RevManifest asset strategy.
+ * This strategy expects a JSON assets map like
+ *
+ * ```
+ * {
+ *     "app.js": "app.13gdr5.js",
+ *     "style.css: "style.lgcf6a.js"
+ * }
+ * ```
+ */
+class RevManifestStrategy extends AssetStrategy
+{
+    /**
+     * {@inheritDoc}
+     */
+    protected $_defaultConfig = [
+        'manifestPath' => WWW_ROOT . 'rev-manifest.json',
+    ];
+
+    /**
+     * {@inheritDoc}
+     */
+    public function get(string $name, ?string $extension = null)
+    {
+        if (!empty($extension)) {
+            $name .= sprintf('.%s', $extension);
+        }
+
+        if (empty($this->assets[$name])) {
+            return null;
+        }
+
+        return $this->assets[$name];
+    }
+}

--- a/src/Utility/AssetsRevisions.php
+++ b/src/Utility/AssetsRevisions.php
@@ -56,7 +56,7 @@ class AssetsRevisions
      *
      * @return void
      */
-    public function clearStrategy(): void
+    public static function clearStrategy(): void
     {
         static::$strategy = null;
     }

--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -358,9 +358,9 @@ class HtmlHelper extends CakeHtmlHelper
     public function script($url, array $options = []): ?string
     {
         if (is_array($url)) {
-            $url = AssetsRevisions::getMulti($url, '.js');
+            $url = AssetsRevisions::getMulti($url, 'js');
         } else {
-            $url = AssetsRevisions::get($url, '.js');
+            $url = AssetsRevisions::get($url, 'js');
         }
 
         return parent::script($url, $options);
@@ -374,11 +374,29 @@ class HtmlHelper extends CakeHtmlHelper
     public function css($url, array $options = []): ?string
     {
         if (is_array($url)) {
-            $url = AssetsRevisions::getMulti($url, '.css');
+            $url = AssetsRevisions::getMulti($url, 'css');
         } else {
-            $url = AssetsRevisions::get($url, '.css');
+            $url = AssetsRevisions::get($url, 'css');
         }
 
         return parent::css($url, $options);
+    }
+
+    /**
+     * Creates link elements for CSS stylesheets and JS by asset name.
+     *
+     * @param string $name The asset name
+     * @param array $options The options to apply
+     * @return string|null
+     */
+    public function assets($name, array $options = []): ?string
+    {
+        $cssOutput = $this->css($name, $options);
+        $jsOutput = $this->script($name, $options);
+        if (empty($cssOutput)) {
+            return $jsOutput;
+        }
+
+        return $cssOutput . (string)$jsOutput;
     }
 }

--- a/tests/TestCase/Utility/Asset/AssetStrategyTest.php
+++ b/tests/TestCase/Utility/Asset/AssetStrategyTest.php
@@ -1,0 +1,98 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2020 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+namespace BEdita\WebTools\Test\TestCase\Utility\Asset\Strategy;
+
+use BEdita\WebTools\Utility\Asset\AssetStrategy;
+use Cake\TestSuite\TestCase;
+use Cake\Utility\Hash;
+
+/**
+ * {@see \BEdita\WebTools\Utility\Asset\AssetStrategy} Test Case
+ *
+ * @coversDefaultClass \BEdita\WebTools\Utility\Asset\AssetStrategy
+ */
+class AssetStrategyTest extends TestCase
+{
+    /**
+     * Return an instance of anonymous class that extends AssetStrategy
+     *
+     * @param array $config The configuration to use
+     * @return AssetStrategy
+     */
+    protected function getInstance(array $config = []): AssetStrategy
+    {
+        return new class($config) extends AssetStrategy {
+
+            public function get(string $name, ?string $extension = null)
+            {
+                return $this->assets;
+            }
+
+        };
+    }
+
+    /**
+     * Data provider for `testManifestPath()`
+     *
+     * @return array
+     */
+    public function manifestPathProvider(): array
+    {
+        return [
+            'default' => [
+                '',
+                [],
+            ],
+            'custom' => [
+                '/manifest/custom/path.json',
+                [
+                    'manifestPath' => '/manifest/custom/path.json',
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Test that manifest path is well configured.
+     *
+     * @param string $expected The expected path
+     * @param array $config The configuration used
+     * @return void
+     *
+     * @dataProvider manifestPathProvider()
+     * @covers ::__construct()
+     */
+    public function testManifestPath(string $expected, array $config): void
+    {
+        $strategy = $this->getInstance($config);
+
+        static::assertEquals($expected, $strategy->getConfig('manifestPath'));
+    }
+
+    /**
+     * Test `loadASsets()`
+     *
+     * @return void
+     *
+     * @covers ::loadAssets()
+     */
+    public function testLoadAssets(): void
+    {
+        $path = WWW_ROOT . 'custom-manifest.json';
+        $expected = json_decode(file_get_contents($path), true);
+        $strategy = $this->getInstance(['manifestPath' => $path]);
+        static::assertEquals($expected, $strategy->get('all'));
+    }
+}

--- a/tests/TestCase/Utility/Asset/AssetStrategyTest.php
+++ b/tests/TestCase/Utility/Asset/AssetStrategyTest.php
@@ -16,7 +16,6 @@ namespace BEdita\WebTools\Test\TestCase\Utility\Asset\Strategy;
 
 use BEdita\WebTools\Utility\Asset\AssetStrategy;
 use Cake\TestSuite\TestCase;
-use Cake\Utility\Hash;
 
 /**
  * {@see \BEdita\WebTools\Utility\Asset\AssetStrategy} Test Case
@@ -33,13 +32,11 @@ class AssetStrategyTest extends TestCase
      */
     protected function getInstance(array $config = []): AssetStrategy
     {
-        return new class($config) extends AssetStrategy {
-
+        return new class ($config) extends AssetStrategy {
             public function get(string $name, ?string $extension = null)
             {
                 return $this->assets;
             }
-
         };
     }
 

--- a/tests/TestCase/Utility/Asset/Strategy/EntrypointsStrategyTest.php
+++ b/tests/TestCase/Utility/Asset/Strategy/EntrypointsStrategyTest.php
@@ -1,0 +1,78 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2020 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+namespace BEdita\WebTools\Test\TestCase\Utility\Asset\Strategy;
+
+use BEdita\WebTools\Utility\Asset\Strategy\EntrypointsStrategy;
+use Cake\TestSuite\TestCase;
+
+/**
+ * {@see \BEdita\WebTools\Utility\Asset\Strategy\EntrypointsStrategy} Test Case
+ *
+ * @coversDefaultClass \BEdita\WebTools\Utility\Asset\Strategy\EntrypointsStrategy
+ */
+class EntrypointsStrategyTest extends TestCase
+{
+    /**
+     * Data provider for `testGet()`
+     *
+     * @return array
+     */
+    public function getProvider(): array
+    {
+        return [
+            'not found' => [
+                null,
+                'gustavo',
+            ],
+            'all assets for entrypoint' => [
+                [
+                    'js' => [
+                        '/build/runtime.f011bcb1.js',
+                    ],
+                    'css' => [
+                        '/build/style.12c5249c.css',
+                    ],
+                ],
+                'style',
+            ],
+            'all js assets for entrypoint' => [
+                [
+                    '/build/runtime.f011bcb1.js',
+                    '/build/0.54651780.js',
+                    '/build/app.82269f26.js',
+                ],
+                'app',
+                'js',
+            ],
+        ];
+    }
+
+    /**
+     * Test that get asset name works as expected.
+     *
+     * @param string $expected The expected path
+     * @param array $name The configuration used
+     * @return void
+     *
+     * @dataProvider getProvider()
+     * @covers ::get()
+     */
+    public function testGet(?array $expected, string $name, ?string $extension = null): void
+    {
+        $strategy = new EntrypointsStrategy(['manifestPath' => WWW_ROOT . 'entrypoints.json']);
+
+        static::assertEquals($expected, $strategy->get($name, $extension));
+    }
+}

--- a/tests/TestCase/Utility/Asset/Strategy/RevManifestStrategyTest.php
+++ b/tests/TestCase/Utility/Asset/Strategy/RevManifestStrategyTest.php
@@ -43,7 +43,7 @@ class RevManifestStrategyTest extends TestCase
             'name and extension' => [
                 'script-622a2cc4f5.js',
                 'script',
-                'js'
+                'js',
             ],
             'not found' => [
                 null,

--- a/tests/TestCase/Utility/Asset/Strategy/RevManifestStrategyTest.php
+++ b/tests/TestCase/Utility/Asset/Strategy/RevManifestStrategyTest.php
@@ -1,0 +1,71 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2020 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+namespace BEdita\WebTools\Test\TestCase\Utility\Asset\Strategy;
+
+use BEdita\WebTools\Utility\Asset\Strategy\RevManifestStrategy;
+use Cake\TestSuite\TestCase;
+
+/**
+ * {@see \BEdita\WebTools\Utility\Asset\Strategy\RevManifestStrategy} Test Case
+ *
+ * @coversDefaultClass \BEdita\WebTools\Utility\Asset\Strategy\RevManifestStrategy
+ */
+class RevManifestStrategyTest extends TestCase
+{
+    /**
+     * Data provider for `testGet()`
+     *
+     * @return array
+     */
+    public function getProvider(): array
+    {
+        return [
+            'name' => [
+                'support.xyz123.js',
+                'support',
+            ],
+            'name with extension' => [
+                'script-622a2cc4f5.js',
+                'script.js',
+            ],
+            'name and extension' => [
+                'script-622a2cc4f5.js',
+                'script',
+                'js'
+            ],
+            'not found' => [
+                null,
+                'gustavo',
+            ],
+        ];
+    }
+
+    /**
+     * Test that get asset name works as expected.
+     *
+     * @param string $expected The expected path
+     * @param array $name The configuration used
+     * @return void
+     *
+     * @dataProvider getProvider()
+     * @covers ::get()
+     */
+    public function testGet(?string $expected, string $name, ?string $extension = null): void
+    {
+        $strategy = new RevManifestStrategy();
+
+        static::assertEquals($expected, $strategy->get($name, $extension));
+    }
+}

--- a/tests/TestCase/Utility/AssetsRevisionsTest.php
+++ b/tests/TestCase/Utility/AssetsRevisionsTest.php
@@ -14,9 +14,9 @@ declare(strict_types=1);
  */
 namespace BEdita\WebTools\Test\TestCase\Utility;
 
-use BEdita\WebTools\Utility\AssetsRevisions;
 use BEdita\WebTools\Utility\Asset\Strategy\EntrypointsStrategy;
 use BEdita\WebTools\Utility\Asset\Strategy\RevManifestStrategy;
+use BEdita\WebTools\Utility\AssetsRevisions;
 use Cake\TestSuite\TestCase;
 
 /**

--- a/tests/TestCase/View/Helper/AssetHelperTest.php
+++ b/tests/TestCase/View/Helper/AssetHelperTest.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
  */
 namespace BEdita\WebTools\Test\TestCase\View\Helper;
 
+use BEdita\WebTools\Utility\Asset\Strategy\RevManifestStrategy;
+use BEdita\WebTools\Utility\AssetsRevisions;
 use BEdita\WebTools\View\Helper\AssetHelper;
 use Cake\TestSuite\TestCase;
 use Cake\View\View;
@@ -34,6 +36,7 @@ class AssetHelperTest extends TestCase
      */
     public function testGet(): void
     {
+        AssetsRevisions::setStrategy(new RevManifestStrategy());
         $Asset = new AssetHelper(new View());
         $result = $Asset->get('script.js');
         static::assertEquals('script-622a2cc4f5.js', $result);

--- a/tests/TestCase/View/Helper/HtmlHelperTest.php
+++ b/tests/TestCase/View/Helper/HtmlHelperTest.php
@@ -14,6 +14,10 @@ declare(strict_types=1);
  */
 namespace BEdita\WebTools\Test\TestCase\View\Helper;
 
+use BEdita\WebTools\Utility\Asset\AssetStrategyInterface;
+use BEdita\WebTools\Utility\Asset\Strategy\EntrypointsStrategy;
+use BEdita\WebTools\Utility\Asset\Strategy\RevManifestStrategy;
+use BEdita\WebTools\Utility\AssetsRevisions;
 use BEdita\WebTools\View\Helper\HtmlHelper;
 use Cake\Http\ServerRequest;
 use Cake\TestSuite\TestCase;
@@ -50,6 +54,7 @@ class HtmlHelperTest extends TestCase
     public function tearDown(): void
     {
         unset($this->Html);
+        AssetsRevisions::clearStrategy();
 
         parent::tearDown();
     }
@@ -496,18 +501,36 @@ class HtmlHelperTest extends TestCase
     {
         return [
             'simple' => [
-                '<script src="/script-622a2cc4f5.js"></script>',
+                ['script' => ['src' => '/script-622a2cc4f5.js']],
                 'script',
+                new RevManifestStrategy(),
             ],
             'not found' => [
-                '<script src="/functions.js"></script>',
+                ['script' => ['src' => '/functions.js']],
                 'functions.js',
+                new RevManifestStrategy(),
             ],
             'multi' => [
-                '<script src="/script-622a2cc4f5.js"></script>' .
-                "\n\t" .
-                '<script src="/page-1x4f92530c.js"></script>',
+                [
+                    ['script' => ['src' => '/script-622a2cc4f5.js']],
+                    '/script',
+                    ['script' => ['src' => '/page-1x4f92530c.js']],
+                    '/script',
+                ],
                 ['script', 'page'],
+                new RevManifestStrategy(),
+            ],
+            'entrypoint app' => [
+                [
+                    ['script' => ['src' => '/build/runtime.f011bcb1.js']],
+                    '/script',
+                    ['script' => ['src' => '/build/0.54651780.js']],
+                    '/script',
+                    ['script' => ['src' => '/build/app.82269f26.js']],
+                    '/script',
+                ],
+                'app',
+                new EntrypointsStrategy(['manifestPath' => WWW_ROOT . 'entrypoints.json']),
             ],
         ];
     }
@@ -515,17 +538,19 @@ class HtmlHelperTest extends TestCase
     /**
      * Test `script` method
      *
+     * @param array $expected The expected result
+     * @param string|string[] $name The asset name
+     * @param \BEdita\WebTools\Utility\Asset\AssetStrategyInterface $strategy The asset strategy to adopt
+     * @return void
+     *
      * @dataProvider scriptProvider()
      * @covers ::script()
-     *
-     * @param string|string[] $expected The expected result
-     * @param string|string[] $name The asset name
-     * @return void
      */
-    public function testScript($expected, $name): void
+    public function testScript($expected, $name, AssetStrategyInterface $strategy): void
     {
+        AssetsRevisions::setStrategy($strategy);
         $result = $this->Html->script($name);
-        static::assertEquals($expected, trim($result));
+        $this->assertHtml($expected, $result);
     }
 
     /**
@@ -537,18 +562,52 @@ class HtmlHelperTest extends TestCase
     {
         return [
             'simple' => [
-                '<link rel="stylesheet" href="/style-b7c54b4c5a.css"/>',
+                [
+                    'link' => [
+                        'rel' => 'stylesheet',
+                        'href' => '/style-b7c54b4c5a.css',
+                    ],
+                ],
                 'style',
+                new RevManifestStrategy(),
             ],
             'not found' => [
-                '<link rel="stylesheet" href="/home.css"/>',
+                [
+                    'link' => [
+                        'rel' => 'stylesheet',
+                        'href' => '/home.css',
+                    ],
+                ],
                 'home.css',
+                new RevManifestStrategy(),
             ],
             'multi' => [
-                '<link rel="stylesheet" href="/style-b7c54b4c5a.css"/>' .
-                "\n\t" .
-                '<link rel="stylesheet" href="/page.css"/>',
+                [
+                    [
+                        'link' => [
+                            'rel' => 'stylesheet',
+                            'href' => '/style-b7c54b4c5a.css',
+                        ],
+                    ],
+                    [
+                        'link' => [
+                            'rel' => 'stylesheet',
+                            'href' => '/page.css',
+                        ],
+                    ],
+                ],
                 ['style', 'page'],
+                new RevManifestStrategy(),
+            ],
+            'entrypoint style' => [
+                [
+                    'link' => [
+                        'rel' => 'stylesheet',
+                        'href' => '/build/style.12c5249c.css',
+                    ],
+                ],
+                'style',
+                new EntrypointsStrategy(['manifestPath' => WWW_ROOT . 'entrypoints.json']),
             ],
         ];
     }
@@ -556,16 +615,73 @@ class HtmlHelperTest extends TestCase
     /**
      * Test `css` method
      *
+     * @param array $expected The expected result
+     * @param string|string[] $name The asset name
+     * @param \BEdita\WebTools\Utility\Asset\AssetStrategyInterface $strategy The asset strategy to adopt
+     * @return void
+     *
      * @dataProvider cssProvider()
      * @covers ::css()
-     *
-     * @param string|string[] $expected The expected result
-     * @param string|string[] $name The asset name
-     * @return void
      */
-    public function testCss($expected, $name): void
+    public function testCss($expected, $name, AssetStrategyInterface $strategy): void
     {
+        AssetsRevisions::setStrategy($strategy);
         $result = $this->Html->css($name);
-        static::assertEquals($expected, trim($result));
+        $this->assertHtml($expected, $result);
+    }
+
+    /**
+     * Data provider for `testAssets` test case.
+     *
+     * @return array
+     */
+    public function assetsProvider(): array
+    {
+        return [
+            'css found and js fallback' => [
+                [
+                    'link' => [
+                        'rel' => 'stylesheet',
+                        'href' => '/style-b7c54b4c5a.css',
+                    ],
+                    'script' => [
+                        'src' => '/style.js',
+                    ],
+                ],
+                'style',
+                new RevManifestStrategy(),
+            ],
+            'entrypoint style' => [
+                [
+                    'link' => [
+                        'rel' => 'stylesheet',
+                        'href' => '/build/style.12c5249c.css'
+                    ],
+                    'script' => [
+                        'src' => '/build/runtime.f011bcb1.js',
+                    ],
+                ],
+                'style',
+                new EntrypointsStrategy(['manifestPath' => WWW_ROOT . 'entrypoints.json']),
+            ],
+        ];
+    }
+
+    /**
+     * Test `asset` method.
+     *
+     * @param array $expected The expected result
+     * @param string|string[] $name The asset name
+     * @param \BEdita\WebTools\Utility\Asset\AssetStrategyInterface $strategy The asset strategy to adopt
+     * @return void
+     *
+     * @dataProvider assetsProvider()
+     * @covers ::assets()
+     */
+    public function testAssets($expected, $name, AssetStrategyInterface $strategy): void
+    {
+        AssetsRevisions::setStrategy($strategy);
+        $result = $this->Html->assets($name);
+        $this->assertHtml($expected, $result);
     }
 }

--- a/tests/TestCase/View/Helper/HtmlHelperTest.php
+++ b/tests/TestCase/View/Helper/HtmlHelperTest.php
@@ -655,7 +655,7 @@ class HtmlHelperTest extends TestCase
                 [
                     'link' => [
                         'rel' => 'stylesheet',
-                        'href' => '/build/style.12c5249c.css'
+                        'href' => '/build/style.12c5249c.css',
                     ],
                     'script' => [
                         'src' => '/build/runtime.f011bcb1.js',

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -58,6 +58,7 @@ define('TMP', sys_get_temp_dir() . DS);
 define('LOGS', TMP . 'logs' . DS);
 define('CACHE', TMP . 'cache' . DS);
 define('CONFIG', ROOT . DS . 'config' . DS);
+define('WWW_ROOT', ROOT . DS . 'webroot' . DS);
 
 define('CAKE_CORE_INCLUDE_PATH', ROOT);
 define('CORE_PATH', CAKE_CORE_INCLUDE_PATH . DS);

--- a/tests/test_app/webroot/custom-manifest.json
+++ b/tests/test_app/webroot/custom-manifest.json
@@ -1,0 +1,4 @@
+{
+    "gustavo.js": "build/gustavo.js",
+    "supporto.css": "build/supporto.css"
+}

--- a/tests/test_app/webroot/entrypoints.json
+++ b/tests/test_app/webroot/entrypoints.json
@@ -1,0 +1,19 @@
+{
+  "entrypoints": {
+    "app": {
+      "js": [
+        "/build/runtime.f011bcb1.js",
+        "/build/0.54651780.js",
+        "/build/app.82269f26.js"
+      ]
+    },
+    "style": {
+      "js": [
+        "/build/runtime.f011bcb1.js"
+      ],
+      "css": [
+        "/build/style.12c5249c.css"
+      ]
+    }
+  }
+}

--- a/tests/test_app/webroot/rev-manifest.json
+++ b/tests/test_app/webroot/rev-manifest.json
@@ -1,0 +1,6 @@
+{
+    "script.js": "script-622a2cc4f5.js",
+    "page.js": "page-1x4f92530c.js",
+    "style.css": "style-b7c54b4c5a.css",
+    "support": "support.xyz123.js"
+}


### PR DESCRIPTION
This PR add a more flexible way to load assets.

For now we have two stategies implemented, one based on `rev-manifest.json` and another based on `entrypoints.json` (see https://symfony.com/doc/current/frontend.html) that for each entrypoint can include  more `js` and `css` assets.

A simple example can be

```json
{
  "entrypoints": {
    "app": {
      "js": [
        "/build/runtime.js",
        "/build/app.js"
      ],
      "css": [
        "/build/app.css"
      ]
    },
    "style": {
      "js": [
        "/build/runtime.js"
      ],
      "css": [
        "/build/style.css"
      ]
    }
  }
}
```

As you can see for `app` entrypoint more assets must be linked.
Using this strategy you can:
* load all css for a `app` entry: `{{ Html.css('app')}}` loads `/build/app.css`
* load all js for `app` entry: `{{Html.script('app)}}` loads `/build/runtime.js` and `/build/app.js`
* load all assets for `app` entry: `{{ Html.assets('app')}}` loads `/build/app.css`, `/build/runtime.js` and `/build/app.js`

----

To choose the appropriate asset strategy to use you can set it in the bootstrap application:

```php
AssetsRevisions::setStrategy(new EntrypointsStrategy());
```