### PR TITLE
Setup Twig environment via configuration

### DIFF
--- a/src/View/TwigView.php
+++ b/src/View/TwigView.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace BEdita\WebTools\View;
 
 use BEdita\WebTools\View\Twig\BeditaTwigExtension;
+use Cake\Core\Configure;
 use Cake\TwigView\View\TwigView as BaseTwigView;
 
 /**
@@ -22,6 +23,17 @@ use Cake\TwigView\View\TwigView as BaseTwigView;
  */
 class TwigView extends BaseTwigView
 {
+    /**
+     * {@inheritDoc}
+     */
+    public function initialize(): void
+    {
+        $environment = Configure::read('Twig.environment', []) + ['strict_variables' => false];
+        $this->setConfig('environment', $environment);
+
+        parent::initialize();
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/src/View/TwigView.php
+++ b/src/View/TwigView.php
@@ -28,7 +28,7 @@ class TwigView extends BaseTwigView
      */
     public function initialize(): void
     {
-        $environment = Configure::read('Twig.environment', []) + ['strict_variables' => false];
+        $environment = (array)Configure::read('Twig.environment', []) + ['strict_variables' => false];
         $this->setConfig('environment', $environment);
 
         parent::initialize();

--- a/tests/TestCase/View/TwigViewTest.php
+++ b/tests/TestCase/View/TwigViewTest.php
@@ -36,5 +36,6 @@ class TwigViewTest extends TestCase
         $extensions = $View->getTwig()->getExtensions();
         static::assertNotEmpty($extensions);
         static::assertArrayHasKey('BEdita\WebTools\View\Twig\BeditaTwigExtension', $extensions);
+        static::assertFalse($View->getConfig('environment.strict_variables'));
     }
 }


### PR DESCRIPTION
This PR introduce the way to setup custom Twig environment using a configuration scoped as `Twig`.
By default `strict_variables` is set to `false`.