### PR TITLE
Add API proxy trait

### DIFF
--- a/src/Controller/ApiProxyTrait.php
+++ b/src/Controller/ApiProxyTrait.php
@@ -123,15 +123,15 @@ trait ApiProxyTrait
                 case 'get':
                     $response = $this->apiClient->get($options['path'], $options['query'], $options['headers']);
                     break;
-                case 'post':
-                    $response = $this->apiClient->post($options['path'], $options['body'], $options['headers']);
-                    break;
-                case 'patch':
-                    $response = $this->apiClient->patch($options['path'], $options['body'], $options['headers']);
-                    break;
-                case 'delete':
-                    $response = $this->apiClient->delete($options['path'], $options['body'], $options['headers']);
-                    break;
+                // case 'post':
+                //     $response = $this->apiClient->post($options['path'], $options['body'], $options['headers']);
+                //     break;
+                // case 'patch':
+                //     $response = $this->apiClient->patch($options['path'], $options['body'], $options['headers']);
+                //     break;
+                // case 'delete':
+                //     $response = $this->apiClient->delete($options['path'], $options['body'], $options['headers']);
+                //     break;
                 default:
                     throw new MethodNotAllowedException();
             }
@@ -162,7 +162,7 @@ trait ApiProxyTrait
         }
         $this->response = $this->response->withStatus($status);
         $errorData = [
-            'status' => $status,
+            'status' => (string)$status,
             'title' => $error->getMessage(),
         ];
         $this->set('error', $errorData);

--- a/src/Controller/ApiProxyTrait.php
+++ b/src/Controller/ApiProxyTrait.php
@@ -19,10 +19,16 @@ use Cake\Http\Exception\MethodNotAllowedException;
 use Cake\Routing\Router;
 use Cake\Utility\Hash;
 
+/**
+ * Trait to directly proxy requests to BE4 API.
+ *
+ * It should be used in controller with route rules configured as
+ *
+ */
 trait ApiProxyTrait
 {
     /**
-     * Replace links with
+     * Base URL used for mask links.
      *
      * @var string
      */
@@ -124,7 +130,7 @@ trait ApiProxyTrait
     }
 
     /**
-     * Handle error
+     * Handle error.
      *
      * @param \Throwable $error The error thrown.
      * @return void
@@ -187,9 +193,10 @@ trait ApiProxyTrait
     }
 
     /**
-     * Mask links across multidimensional array inside an array relationships data.
+     * Mask links across multidimensional array.
+     * By default search for `relationships` and mask their `links`.
      *
-     * @param array $data The data with relationships and links to mask
+     * @param array $data The data with links to mask
      * @param string $path The path to search for
      * @param string $key The key on which are the links
      * @return array

--- a/src/Controller/ApiProxyTrait.php
+++ b/src/Controller/ApiProxyTrait.php
@@ -1,0 +1,233 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2020 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+namespace BEdita\WebTools\Controller;
+
+use BEdita\SDK\BEditaClientException;
+use Cake\Http\Exception\MethodNotAllowedException;
+use Cake\Routing\Router;
+use Cake\Utility\Hash;
+
+trait ApiProxyTrait
+{
+    /**
+     * Replace links with
+     *
+     * @var string
+     */
+    protected $baseUrl = '';
+
+    /**
+     * {@inheritDoc}
+     *
+     * @codeCoverageIgnore
+     */
+    public function initialize(): void
+    {
+        parent::initialize();
+
+        $this->viewBuilder()
+            ->setClassName('Json')
+            ->setOption('serialize', true);
+    }
+
+    /**
+     * Set base URL used for mask links removing trailing slashes.
+     *
+     * @param string $path The path on which build base URL
+     * @return void
+     */
+    protected function setBaseUrl($path): void
+    {
+        $requestPath = $this->request->getPath();
+        $basePath = substr($requestPath, 0, strpos($requestPath, $path));
+        $this->baseUrl = Router::url(rtrim($basePath, '/'), true);
+    }
+
+    /**
+     * Proxy for GET requests to BEdita4 API
+     *
+     * @param string $path The path for API request
+     * @return void
+     */
+    public function get($path = '')
+    {
+        $this->setBaseUrl($path);
+        $this->request([
+            'method' => 'get',
+            'path' => $path,
+            'query' => $this->request->getQueryParams(),
+        ]);
+    }
+
+    /**
+     * Routes a request to the API handling response and errors.
+     *
+     * `$options` are:
+     * - method => the HTTP request method
+     * - path => a string representing the complete endpoint path
+     * - query => an array of query strings
+     * - body => the body sent
+     * - headers => an array of headers
+     *
+     * @param array $options The request options
+     * @return void
+     */
+    protected function request(array $options): void
+    {
+        $options += [
+            'method' => '',
+            'path' => '',
+            'query' => null,
+            'body' => null,
+            'headers' => null,
+        ];
+
+        try {
+            switch (strtolower($options['method'])) {
+                case 'get':
+                    $response = $this->apiClient->get($options['path'], $options['query'], $options['headers']);
+                    break;
+                case 'post':
+                    $response = $this->apiClient->post($options['path'], $options['body'], $options['headers']);
+                    break;
+                case 'patch':
+                    $response = $this->apiClient->patch($options['path'], $options['body'], $options['headers']);
+                    break;
+                case 'delete':
+                    $response = $this->apiClient->delete($options['path'], $options['body'], $options['headers']);
+                    break;
+                default:
+                    throw new MethodNotAllowedException();
+            }
+
+            if (empty($response) || !is_array($response)) {
+                return;
+            }
+
+            $response = $this->maskResponseLinks($response);
+            $this->set($response);
+        } catch (\Throwable $e) {
+            $this->handleError($e);
+        }
+    }
+
+    /**
+     * Handle error
+     *
+     * @param \Throwable $error The error thrown.
+     * @return void
+     */
+    protected function handleError(\Throwable $error): void
+    {
+        $status = $error->getCode();
+        if ($status < 100 || $status > 599) {
+            $status = 500;
+        }
+        $this->response = $this->response->withStatus($status);
+        $errorData = [
+            'status' => $status,
+            'title' => $error->getMessage(),
+        ];
+        $this->set('error', $errorData);
+
+        if (!$error instanceof BEditaClientException) {
+            return;
+        }
+
+        $errorAttributes = $error->getAttributes();
+        if (!empty($errorAttributes)) {
+            $this->set('error', $errorAttributes);
+        }
+    }
+
+    /**
+     * Mask links of response to not expose API URL.
+     *
+     * @param array $response The response from API
+     * @return array
+     */
+    protected function maskResponseLinks(array $response): array
+    {
+        $response = $this->maskLinks($response, '$id');
+        $response = $this->maskLinks($response, 'links');
+        $response = $this->maskLinks($response, 'meta.schema');
+
+        if (!empty($response['meta']['resources'])) {
+            $response = $this->maskMultiLinks($response, 'meta.resources', 'href');
+        }
+
+        $data = Hash::get($response, 'data');
+        if (empty($data)) {
+            return $response;
+        }
+
+        if (Hash::numeric(array_keys($data))) {
+            foreach ($data as $key => &$item) {
+                $item = $this->maskLinks($item, 'links');
+                $item = $this->maskMultiLinks($item);
+            }
+            $response['data'] = $data;
+        } else {
+            $response['data']['relationships'] = $this->maskMultiLinks($data);
+        }
+
+        return $response;
+    }
+
+    /**
+     * Mask links across multidimensional array inside an array relationships data.
+     *
+     * @param array $data The data with relationships and links to mask
+     * @param string $path The path to search for
+     * @param string $key The key on which are the links
+     * @return array
+     */
+    protected function maskMultiLinks(array $data, $path = 'relationships', $key = 'links'): array
+    {
+        $relationships = Hash::get($data, $path, []);
+        foreach ($relationships as &$rel) {
+            $rel = $this->maskLinks($rel, $key);
+        }
+
+        return Hash::insert($data, $path, $relationships);
+    }
+
+    /**
+     * Mask links found in `$path`
+     *
+     * @param array|string $data The data with links to mask
+     * @param string $path The path to search for
+     * @return array
+     */
+    protected function maskLinks($data, $path): array
+    {
+        $links = Hash::get($data, $path, []);
+        if (empty($links)) {
+            return $data;
+        }
+
+        if (is_string($links)) {
+            $links = str_replace($this->apiClient->getApiBaseUrl(), $this->baseUrl, $links);
+
+            return Hash::insert($data, $path, $links);
+        }
+
+        foreach ($links as &$link) {
+            $link = str_replace($this->apiClient->getApiBaseUrl(), $this->baseUrl, $link);
+        }
+
+        return Hash::insert($data, $path, $links);
+    }
+}

--- a/tests/TestCase/Controller/ApiProxyTraitTest.php
+++ b/tests/TestCase/Controller/ApiProxyTraitTest.php
@@ -82,7 +82,7 @@ class ApiProxyTraitTest extends TestCase
      * @covers ::initialize()
      * @covers ::get()
      * @covers ::setBaseUrl()
-     * @covers ::request()
+     * @covers ::apiRequest()
      * @covers ::maskResponseLinks()
      * @covers ::maskMultiLinks()
      * @covers ::maskLinks()
@@ -121,7 +121,7 @@ class ApiProxyTraitTest extends TestCase
      * @return void
      *
      * @covers ::get()
-     * @covers ::request()
+     * @covers ::apiRequest()
      * @covers ::handleError()
      */
     public function testNotFoundError(): void

--- a/tests/TestCase/Controller/ApiProxyTraitTest.php
+++ b/tests/TestCase/Controller/ApiProxyTraitTest.php
@@ -14,9 +14,113 @@ declare(strict_types=1);
  */
 namespace BEdita\WebTools\Test\TestCase\Controller;
 
+use BEdita\WebTools\ApiClientProvider;
+use Cake\Routing\Router;
+use Cake\TestSuite\IntegrationTestTrait;
 use Cake\TestSuite\TestCase;
+use Cake\Utility\Hash;
 
+/**
+ * ApiProxyTraitTest class
+ *
+ * {@see \BEdita\WebTools\Controller\ApiProxyTrait} Test Case
+ *
+ * @coversDefaultClass \BEdita\WebTools\Controller\ApiProxyTrait
+ */
 class ApiProxyTraitTest extends TestCase
 {
+    use IntegrationTestTrait;
 
+    /**
+     * Instance of BEditaClient
+     *
+     * @var \BEdita\SDK\BEditaClient
+     */
+    protected $apiClient = null;
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->apiClient = ApiClientProvider::getApiClient();
+        $response = $this->apiClient->authenticate(env('BEDITA_ADMIN_USR'), env('BEDITA_ADMIN_PWD'));
+        $this->apiClient->setupTokens($response['meta']);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function tearDown(): void
+    {
+        parent::tearDown();
+
+        $this->apiClient = null;
+    }
+
+    /**
+     * Test get() method
+     *
+     * @return void
+     *
+     * @covers ::initialize()
+     * @covers ::get()
+     * @covers ::setBaseUrl()
+     * @covers ::request()
+     * @covers ::maskResponseLinks()
+     * @covers ::maskMultiLinks()
+     * @covers ::maskLinks()
+     */
+    public function testGet(): void
+    {
+        $this->get('/api/users/1');
+        $this->assertResponseOk();
+        $this->assertContentType('application/json');
+        $data = $this->viewVariable('data');
+        $links = $this->viewVariable('links');
+        $meta = $this->viewVariable('meta');
+        static::assertNotEmpty($data);
+        static::assertNotEmpty($links);
+        static::assertNotEmpty($meta);
+        static::assertEquals('1', Hash::get($data, 'id'));
+
+        $response = json_decode((string)$this->_response, true);
+        static::assertArrayHasKey('data', $response);
+        static::assertArrayHasKey('links', $response);
+        static::assertArrayHasKey('meta', $response);
+
+        $baseUrl = Router::url('/', true);
+        foreach ($response['links'] as $link) {
+            static::assertStringContainsString($baseUrl, $link);
+        }
+
+        foreach (Hash::extract($response, 'data.relationships.{s}.links') as $link) {
+            static::assertStringContainsString($baseUrl, $link);
+        }
+    }
+
+    /**
+     * Test non found error proxied from API.
+     *
+     * @return void
+     *
+     * @covers ::get()
+     * @covers ::request()
+     * @covers ::handleError()
+     */
+    public function testNotFoundError(): void
+    {
+        $this->get('/api/users/1000');
+        $this->assertResponseError();
+        $this->assertContentType('application/json');
+        $error = $this->viewVariable('error');
+        static::assertNotEmpty($error);
+
+        $response = json_decode((string)$this->_response, true);
+        static::assertArrayHasKey('error', $response);
+        static::assertArrayHasKey('status', $response['error']);
+        static::assertArrayHasKey('title', $response['error']);
+    }
 }

--- a/tests/TestCase/Controller/ApiProxyTraitTest.php
+++ b/tests/TestCase/Controller/ApiProxyTraitTest.php
@@ -1,0 +1,22 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2020 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+namespace BEdita\WebTools\Test\TestCase\Controller;
+
+use Cake\TestSuite\TestCase;
+
+class ApiProxyTraitTest extends TestCase
+{
+
+}

--- a/tests/test_app/TestApp/Application.php
+++ b/tests/test_app/TestApp/Application.php
@@ -5,6 +5,8 @@ namespace TestApp;
 
 use Cake\Http\BaseApplication;
 use Cake\Http\MiddlewareQueue;
+use Cake\Routing\Middleware\RoutingMiddleware;
+use Cake\Routing\RouteBuilder;
 
 /**
  * Application setup class.
@@ -16,9 +18,31 @@ class Application extends BaseApplication
 {
     /**
      * {@inheritDoc}
+     *
+     * Do not require config/bootstrap.php
+     */
+    public function bootstrap(): void
+    {
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function routes(RouteBuilder $routes): void
+    {
+        // add rules for ApiProxyTrait
+        $routes->scope('/api', ['_namePrefix' => 'api:'], function (RouteBuilder $routes) {
+            $routes->get('/**', ['controller' => 'Api', 'action' => 'get'], 'get');
+        });
+    }
+
+    /**
+     * {@inheritDoc}
      */
     public function middleware(MiddlewareQueue $middleware): MiddlewareQueue
     {
+        $middleware->add(new RoutingMiddleware($this));
+
         return $middleware;
     }
 }

--- a/tests/test_app/TestApp/Controller/ApiController.php
+++ b/tests/test_app/TestApp/Controller/ApiController.php
@@ -1,0 +1,23 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2018 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+namespace TestApp\Controller;
+
+use BEdita\WebTools\Controller\ApiProxyTrait;
+use Cake\Controller\Controller;
+
+class ApiController extends Controller
+{
+    use ApiProxyTrait;
+}


### PR DESCRIPTION
This PR introduce the `ApiProxyTrait` that used from a controller allow to proxy requests to BE4 API and respond  with its raw response body. 

To avoid exposing BE4 API url the links are masked, replacing it with app url.