### PR TITLE
ApiProxyTrait serialize only defined vars

### DIFF
--- a/src/Controller/ApiProxyTrait.php
+++ b/src/Controller/ApiProxyTrait.php
@@ -78,9 +78,7 @@ trait ApiProxyTrait
             $this->apiClient = ApiClientProvider::getApiClient();
         }
 
-        $this->viewBuilder()
-            ->setClassName('Json')
-            ->setOption('serialize', true);
+        $this->viewBuilder()->setClassName('Json');
     }
 
     /**
@@ -153,12 +151,16 @@ trait ApiProxyTrait
                     throw new MethodNotAllowedException();
             }
 
-            if (empty($response) || !is_array($response)) {
+            if ($response === null) {
+                $this->autoRender = false;
+                $this->response = $this->response->withStringBody(null);
+
                 return;
             }
 
             $response = $this->maskResponseLinks($response);
             $this->set($response);
+            $this->viewBuilder()->setOption('serialize', array_keys($response));
         } catch (\Throwable $e) {
             $this->handleError($e);
         }
@@ -183,6 +185,7 @@ trait ApiProxyTrait
             'title' => $error->getMessage(),
         ];
         $this->set('error', $errorData);
+        $this->viewBuilder()->setOption('serialize', ['error']);
 
         if (!$error instanceof BEditaClientException) {
             return;

--- a/tests/test_app/TestApp/Controller/ApiController.php
+++ b/tests/test_app/TestApp/Controller/ApiController.php
@@ -16,8 +16,19 @@ namespace TestApp\Controller;
 
 use BEdita\WebTools\Controller\ApiProxyTrait;
 use Cake\Controller\Controller;
+use Cake\Event\EventInterface;
 
 class ApiController extends Controller
 {
     use ApiProxyTrait;
+
+    /**
+     * {@inheritDoc}
+     */
+    public function beforeFilter(EventInterface $event)
+    {
+        parent::beforeFilter($event);
+
+        $this->set('varNotSerialized', true);
+    }
 }


### PR DESCRIPTION
Previously to this PR if a controller that uses `ApiProxyTrait` set a variable, it was serialized in json compromising the API response.