### PR TITLE
ApiProxyTrait: fix mask relationships when a single resource is requested

### DIFF
--- a/src/Controller/ApiProxyTrait.php
+++ b/src/Controller/ApiProxyTrait.php
@@ -225,7 +225,7 @@ trait ApiProxyTrait
             }
             $response['data'] = $data;
         } else {
-            $response['data']['relationships'] = $this->maskMultiLinks($data);
+            $response['data'] = $this->maskMultiLinks($data);
         }
 
         return (array)$response;

--- a/tests/TestCase/Controller/ApiProxyTraitTest.php
+++ b/tests/TestCase/Controller/ApiProxyTraitTest.php
@@ -114,7 +114,7 @@ class ApiProxyTraitTest extends TestCase
             static::assertStringStartsWith($baseUrl, $link);
         }
 
-        $relationshipsLinks = Hash::extract($response, 'data.relationships.{s}.links');
+        $relationshipsLinks = (array)Hash::extract($response, 'data.relationships.{s}.links.{s}');
         static::assertNotEmpty($relationshipsLinks);
 
         foreach ($relationshipsLinks as $link) {
@@ -175,7 +175,10 @@ class ApiProxyTraitTest extends TestCase
         $this->assertContentType('application/json');
         $response = json_decode((string)$this->_response, true);
 
-        foreach (Hash::extract($response, 'data.{n}.relationships.{s}.links.{s}') as $link) {
+        $relationshipsLinks = (array)Hash::extract($response, 'data.{n}.relationships.{s}.links.{s}');
+        static::assertNotEmpty($relationshipsLinks);
+
+        foreach ($relationshipsLinks as $link) {
             static::assertStringStartsWith($this->getBaseUrl(), $link);
         }
     }

--- a/tests/TestCase/Controller/ApiProxyTraitTest.php
+++ b/tests/TestCase/Controller/ApiProxyTraitTest.php
@@ -111,11 +111,14 @@ class ApiProxyTraitTest extends TestCase
 
         $baseUrl = $this->getBaseUrl();
         foreach ($response['links'] as $link) {
-            static::assertStringContainsString($baseUrl, $link);
+            static::assertStringStartsWith($baseUrl, $link);
         }
 
-        foreach (Hash::extract($response, 'data.relationships.{s}.links') as $link) {
-            static::assertStringContainsString($baseUrl, $link);
+        $relationshipsLinks = Hash::extract($response, 'data.relationships.{s}.links');
+        static::assertNotEmpty($relationshipsLinks);
+
+        foreach ($relationshipsLinks as $link) {
+            static::assertStringStartsWith($baseUrl, $link);
         }
     }
 
@@ -155,7 +158,7 @@ class ApiProxyTraitTest extends TestCase
         $this->assertResponseOk();
         $this->assertContentType('application/json');
         $response = json_decode((string)$this->_response, true);
-        static::assertStringContainsString($this->getBaseUrl(), Hash::get($response, '$id'));
+        static::assertStringStartsWith($this->getBaseUrl(), Hash::get($response, '$id'));
     }
 
     /**
@@ -173,7 +176,7 @@ class ApiProxyTraitTest extends TestCase
         $response = json_decode((string)$this->_response, true);
 
         foreach (Hash::extract($response, 'data.{n}.relationships.{s}.links.{s}') as $link) {
-            static::assertStringContainsString($this->getBaseUrl(), $link);
+            static::assertStringStartsWith($this->getBaseUrl(), $link);
         }
     }
 
@@ -192,7 +195,7 @@ class ApiProxyTraitTest extends TestCase
         $response = json_decode((string)$this->_response, true);
 
         foreach (Hash::extract($response, 'meta.resources.{s}.href') as $link) {
-            static::assertStringContainsString($this->getBaseUrl(), $link);
+            static::assertStringStartsWith($this->getBaseUrl(), $link);
         }
     }
 


### PR DESCRIPTION
There was a bug requesting single resource/object as `GET /api/users/1`.
In those requests links inside `relationships` were not correctly masked.

This PR fix this behavior and fix unit tests.