### PR TITLE
Introduce cache for ThumbHelper

### DIFF
--- a/src/View/Helper/ThumbHelper.php
+++ b/src/View/Helper/ThumbHelper.php
@@ -15,10 +15,10 @@ declare(strict_types=1);
 namespace BEdita\WebTools\View\Helper;
 
 use BEdita\WebTools\ApiClientProvider;
-use Cake\Log\LogTrait;
-use Cake\View\Helper;
 use Cake\Cache\Cache;
+use Cake\Log\LogTrait;
 use Cake\Utility\Hash;
+use Cake\View\Helper;
 
 /**
  * Helper to obtain thumbnail url
@@ -190,7 +190,7 @@ class ThumbHelper extends Helper
     /**
      * Retrieve thumb URL using cache.
      * Silently fail with log if no image 'id' is found in array.
-     * 
+     *
      * @param  array  $image   Image object array containing at least `id`
      * @param  string $options Thumb options
      * @return string
@@ -213,5 +213,4 @@ class ThumbHelper extends Helper
             $this->getConfig('cache')
         );
     }
-
 }

--- a/src/View/Helper/ThumbHelper.php
+++ b/src/View/Helper/ThumbHelper.php
@@ -17,6 +17,8 @@ namespace BEdita\WebTools\View\Helper;
 use BEdita\WebTools\ApiClientProvider;
 use Cake\Log\LogTrait;
 use Cake\View\Helper;
+use Cake\Cache\Cache;
+use Cake\Utility\Hash;
 
 /**
  * Helper to obtain thumbnail url
@@ -24,6 +26,15 @@ use Cake\View\Helper;
 class ThumbHelper extends Helper
 {
     use LogTrait;
+
+    /**
+     * Default config for this helper.
+     *
+     * @var array
+     */
+    protected $_defaultConfig = [
+        'cache' => '_thumbs_',
+    ];
 
     /**
      * @var int Thumb not available
@@ -49,6 +60,19 @@ class ThumbHelper extends Helper
      * @var int Thumb is OK
      */
     public const OK = 1;
+
+    /**
+     * Use 'default' as fallback if no cache configuration is found.
+     *
+     * @param array $config The configuration settings provided to this helper.
+     * @return void
+     */
+    public function initialize(array $config): void
+    {
+        if (Cache::getConfig($this->getConfig('cache')) === null) {
+            $this->setConfig('cache', 'default');
+        }
+    }
 
     /**
      * Verify status of image thumb.
@@ -162,4 +186,32 @@ class ThumbHelper extends Helper
 
         return false;
     }
+
+    /**
+     * Retrieve thumb URL using cache.
+     * Silently fail with log if no image 'id' is found in array.
+     * 
+     * @param  array  $image   Image object array containing at least `id`
+     * @param  string $options Thumb options
+     * @return string
+     */
+    public function getUrl(array $image, array $options = []): string
+    {
+        if (empty($image['id'])) {
+            $this->log(sprintf('Missing image ID - %s', json_encode($image)), 'warning');
+
+            return '';
+        }
+        $thumbHash = md5((string)Hash::get($image, 'meta.media_url') . json_encode($options));
+        $key = sprintf('%d_%s', $image['id'], $thumbHash);
+
+        return (string)Cache::remember(
+            $key,
+            function () use ($image, $options) {
+                return $this->url($image['id'], $options);
+            },
+            $this->getConfig('cache')
+        );
+    }
+
 }

--- a/tests/TestCase/View/Helper/ThumbHelperTest.php
+++ b/tests/TestCase/View/Helper/ThumbHelperTest.php
@@ -17,8 +17,10 @@ namespace BEdita\WebTools\Test\TestCase\View\Helper;
 use BEdita\SDK\BEditaClient;
 use BEdita\WebTools\ApiClientProvider;
 use BEdita\WebTools\View\Helper\ThumbHelper;
+use Cake\Cache\Cache;
 use Cake\Core\Configure;
 use Cake\TestSuite\TestCase;
+use Cake\Utility\Hash;
 use Cake\View\View;
 
 /**
@@ -98,6 +100,52 @@ class ThumbHelperTest extends TestCase
         $response = $apiClient->createMediaFromStream($streamId, $type, $body);
 
         return (int)$response['data']['id'];
+    }
+
+    /**
+     * Create image and media stream for test.
+     * Return id
+     *
+     * @param string $filename the File name.
+     * @return array|null The image Data.
+     */
+    private function _imageData($filename = 'test.png'): ?array
+    {
+        $apiClient = ApiClientProvider::getApiClient();
+
+        $filepath = sprintf('%s/tests/files/%s', getcwd(), $filename);
+        $response = $apiClient->upload($filename, $filepath);
+
+        $streamId = $response['data']['id'];
+        $response = $apiClient->get(sprintf('/streams/%s', $streamId));
+
+        $type = 'images';
+        $title = 'The test image';
+        $attributes = compact('title');
+        $data = compact('type', 'attributes');
+        $body = compact('data');
+        $response = $apiClient->createMediaFromStream($streamId, $type, $body);
+        $response['id'] = (int)$response['data']['id'];
+
+        return $response;
+    }
+
+    /**
+     * Initialize Thumb Helper test
+     *
+     * @return void
+     */
+    public function testInitialize(): void
+    {
+        $this->Thumb = new ThumbHelper(new View());
+        $actual = $this->Thumb->getConfig('cache');
+        $expected = 'default';
+        static::assertEquals($expected, $actual);
+
+        Cache::setConfig('cache', 'default');
+        $actual = $this->Thumb->getConfig('cache');
+        $expected = 'default';
+        static::assertEquals($expected, $actual);
     }
 
     /**
@@ -358,5 +406,41 @@ class ThumbHelperTest extends TestCase
     {
         $status = $this->Thumb->status(null);
         static::assertEquals($status, ThumbHelper::NOT_ACCEPTABLE);
+    }
+
+    /**
+     * Test `getUrl()` method for 3 cases:
+     * 1) image with empty id
+     * 2) image NOT present in cache
+     * 3) image already present in cache
+     *
+     * @covers ::getUrl()
+     * @return void
+     */
+    public function testGetUrl(): void
+    {
+        //empty id
+        $this->Thumb = new ThumbHelper(new View());
+        $id = [];
+        $actual = $this->Thumb->getUrl($id);
+        $expected = '';
+        static::assertEquals($expected, $actual);
+
+        //fake data NOT in cache
+        $image = $this->_imageData();
+        $options = [];
+        $expected = $this->Thumb->url($image['id'], $options);
+        $actual = $this->Thumb->getUrl($image);
+        static::assertEquals($expected, $actual);
+
+        //fake data in cache
+        $image = $this->_imageData();
+        $options = [];
+        $actual = $this->Thumb->getUrl($image);
+        $thumbHash = md5((string)Hash::get($image, 'meta.media_url') . json_encode($options));
+        $key = sprintf('%d_%s', $image['id'], $thumbHash);
+        Cache::write($key, $actual);
+        $expected = $this->Thumb->url($image['id'], []);
+        static::assertEquals($expected, $actual);
     }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -84,6 +84,11 @@ Configure::write('Error', [
 ]);
 
 Cache::setConfig([
+    'default' => [
+        'className' => 'File',
+        'path' => CACHE,
+        'url' => env('CACHE_DEFAULT_URL', null),
+    ],
     '_cake_core_' => [
         'engine' => 'File',
         'prefix' => 'cake_core_',


### PR DESCRIPTION
This PR is a proposal to add cache system for ThumbHelper. This feature allow to load a media directly from cache when it is present, otherwise it is loaded through the API call.

Add a initialize method for ThumbHelper to introduce a default cache:

```
public function initialize(array $config): void
    {
        if (Cache::getConfig($this->getConfig('cache')) === null) {
            $this->setConfig('cache', 'default');
        }
    }
```
The method added is `getUrl(array $image, array $options = []): string`.
His responsibility is to generate a key for media like a md5 hash with:

```
 $thumbHash = md5((string)Hash::get($image, 'meta.media_url') . json_encode($options));
 $key = sprintf('%d_%s', $image['id'], $thumbHash);
```
To load a media that is already present in cache it run this snippet, which return the url of media. If media is not present then save his url on cache:

```
return (string)Cache::remember(
            $key,
            function () use ($image, $options) {
                return $this->url($image['id'], $options);
            },
            $this->getConfig('cache')
);
```


