### PR TITLE
feat: thumb getUrl null param

### DIFF
--- a/src/View/Helper/ThumbHelper.php
+++ b/src/View/Helper/ThumbHelper.php
@@ -197,13 +197,13 @@ class ThumbHelper extends Helper
      * Retrieve thumb URL using cache.
      * Silently fail with log if no image 'id' is found in array.
      *
-     * @param  array  $image   Image object array containing at least `id`
-     * @param  string $options Thumb options
+     * @param array|null $image Image object array containing at least `id`
+     * @param string $options Thumb options
      * @return string
      */
-    public function getUrl(array $image, array $options = []): string
+    public function getUrl(?array $image, array $options = []): string
     {
-        if (empty($image['id'])) {
+        if (empty($image) || empty($image['id'])) {
             $this->log(sprintf('Missing image ID - %s', json_encode($image)), 'warning');
 
             return '';

--- a/tests/TestCase/View/Helper/ThumbHelperTest.php
+++ b/tests/TestCase/View/Helper/ThumbHelperTest.php
@@ -427,35 +427,30 @@ class ThumbHelperTest extends TestCase
     }
 
     /**
-     * Test `getUrl()` method for 3 cases:
-     * 1) image with empty id
-     * 2) image NOT present in cache
-     * 3) image already present in cache
+     * Test `getUrl()`
      *
      * @covers ::getUrl()
      * @return void
      */
     public function testGetUrl(): void
     {
-        //empty id
+        //null and []
         $this->Thumb = new ThumbHelper(new View());
-        $id = [];
-        $actual = $this->Thumb->getUrl($id);
-        $expected = '';
-        static::assertEquals($expected, $actual);
+        $actual = $this->Thumb->getUrl(null);
+        static::assertEquals('', $actual);
+        $actual = $this->Thumb->getUrl([]);
+        static::assertEquals('', $actual);
 
         //fake data NOT in cache
         $image = $this->_imageData();
-        $options = [];
-        $expected = $this->Thumb->url($image['id'], $options);
+        $expected = $this->Thumb->url($image['id'], []);
         $actual = $this->Thumb->getUrl($image);
         static::assertEquals($expected, $actual);
 
         //fake data in cache
         $image = $this->_imageData();
-        $options = [];
         $actual = $this->Thumb->getUrl($image);
-        $thumbHash = md5((string)Hash::get($image, 'meta.media_url') . json_encode($options));
+        $thumbHash = md5((string)Hash::get($image, 'meta.media_url') . json_encode([]));
         $key = sprintf('%d_%s', $image['id'], $thumbHash);
         Cache::write($key, $actual);
         $expected = $this->Thumb->url($image['id'], []);


### PR DESCRIPTION
This provides a less strict way to use `Thumb::getUrl`: parameter `$image` can be null.