### PR TITLE
Handle HTTP status code for BEditaClientException

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,11 +49,6 @@
             "@test",
             "@cs-check"
         ],
-        "cs-setup": [
-            "vendor/bin/phpcs --config-set installed_paths vendor/cakephp/cakephp-codesniffer",
-            "vendor/bin/phpcs --config-set default_standard CakePHP",
-            "vendor/bin/phpcs --config-set colors 1"
-        ],
         "cs-check": "vendor/bin/phpcs --colors -p --standard=vendor/cakephp/cakephp-codesniffer/CakePHP ./src ./tests",
         "cs-fix": "vendor/bin/phpcbf --colors --standard=vendor/cakephp/cakephp-codesniffer/CakePHP ./src ./tests",
         "test": "vendor/bin/phpunit --colors=always",

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<ruleset name="App">
+    <arg name="colors"/>
+    <config name="installed_paths" value="../../cakephp/cakephp-codesniffer"/>
+
+    <rule ref="CakePHP"/>
+</ruleset>

--- a/src/Error/ExceptionRenderer.php
+++ b/src/Error/ExceptionRenderer.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 
 namespace BEdita\WebTools\Error;
 
+use BEdita\SDK\BEditaClientException;
 use Cake\Error\ExceptionRenderer as CakeExceptionRenderer;
 use Cake\Http\Response;
 use Cake\Log\LogTrait;
@@ -38,6 +39,20 @@ class ExceptionRenderer extends CakeExceptionRenderer
         }
 
         return $this->template = $template;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * Handle BEditaClientException.
+     */
+    protected function getHttpCode(\Throwable $exception): int
+    {
+        if ($exception instanceof BEditaClientException) {
+            return $exception->getCode();
+        }
+
+        return parent::getHttpCode($exception);
     }
 
     /**

--- a/tests/TestCase/Error/ExceptionRendererTest.php
+++ b/tests/TestCase/Error/ExceptionRendererTest.php
@@ -93,6 +93,7 @@ class ExceptionRendererTest extends TestCase
      * @return void
      * @dataProvider templateProvider
      * @covers ::_template()
+     * @covers ::getHttpCode()
      */
     public function testTemplate(\Exception $exception, $expected)
     {

--- a/tests/TestCase/Error/ExceptionRendererTest.php
+++ b/tests/TestCase/Error/ExceptionRendererTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
  */
 namespace BEdita\WebTools\Test\TestCase\Error;
 
+use BEdita\SDK\BEditaClientException;
 use BEdita\WebTools\Error\ExceptionRenderer;
 use Cake\Controller\ErrorController;
 use Cake\Event\Event;
@@ -72,6 +73,14 @@ class ExceptionRendererTest extends TestCase
             '500 exception' => [
                 new InternalErrorException('hello'),
                 'error500',
+            ],
+            '503 BEditaClientException' => [
+                new BEditaClientException('hello'),
+                'error500',
+            ],
+            '404 BEditaClientException' => [
+                new BEditaClientException('hello', 404),
+                'error400',
             ],
         ];
     }


### PR DESCRIPTION
This PR fix a wrong behavior in `ExceptionRenderer` introduced after the upgrade to CakePHP 4.2.
The template used for rendering error was wrong when occurs a `BEditaClientException` because CakePHP `ExceptionRenderer` set the HTTP status code just for `HttpException`. 

Ref: https://book.cakephp.org/4/en/appendices/4-2-migration-guide.html#error 

**Bonus track**
Introduce PHP Code Sniffer configuration that replace the `cs-setup` script.