### PR TITLE
ApiFormatterComponent::extractFromIncluded, when included data is a 1-1 relationship [master, 3.x]

### DIFF
--- a/src/Controller/Component/ApiFormatterComponent.php
+++ b/src/Controller/Component/ApiFormatterComponent.php
@@ -90,6 +90,13 @@ class ApiFormatterComponent extends Component
      */
     protected function extractFromIncluded(Collection $included, array $relationshipData): array
     {
+        // case is 1-1 relationship - object relation in translations is a special case
+        if (array_key_exists('id', $relationshipData)) {
+            return (array)$included->firstMatch([
+                'type' => $relationshipData['type'],
+                'id' => $relationshipData['id'],
+            ]);
+        }
         foreach ($relationshipData as &$data) {
             $data = (array)$included->firstMatch([
                 'type' => $data['type'],

--- a/tests/TestCase/Controller/Component/ApiFormatterComponentTest.php
+++ b/tests/TestCase/Controller/Component/ApiFormatterComponentTest.php
@@ -109,6 +109,16 @@ class ApiFormatterComponentTest extends TestCase
                                 'title' => 'test',
                             ],
                             'relationships' => [
+                                'object' => [
+                                    'links' => [],
+                                    'data' => [
+                                        'id' => '999999',
+                                        'type' => 'dummies',
+                                        'attributes' => [
+                                            'title' => 'dummy object',
+                                        ],
+                                    ],
+                                ],
                                 'streams' => [
                                     'links' => [],
                                     'data' => [
@@ -122,6 +132,13 @@ class ApiFormatterComponentTest extends TestCase
                         ],
                     ],
                     'included' => [
+                        [
+                            'id' => '999999',
+                            'type' => 'dummies',
+                            'attributes' => [
+                                'title' => 'dummy object',
+                            ],
+                        ],
                         [
                             'id' => 'af829cbb-c570-4282-94c3-782cf315983a',
                             'type' => 'streams',

--- a/tests/TestCase/Controller/Component/ApiFormatterComponentTest.php
+++ b/tests/TestCase/Controller/Component/ApiFormatterComponentTest.php
@@ -141,6 +141,16 @@ class ApiFormatterComponentTest extends TestCase
                                 'title' => 'test',
                             ],
                             'relationships' => [
+                                'object' => [
+                                    'links' => [],
+                                    'data' => [
+                                        'id' => '999999',
+                                        'type' => 'dummies',
+                                        'attributes' => [
+                                            'title' => 'dummy object',
+                                        ],
+                                    ],
+                                ],
                                 'streams' => [
                                     'links' => [],
                                     'data' => [
@@ -158,6 +168,13 @@ class ApiFormatterComponentTest extends TestCase
                         ],
                     ],
                     'included' => [
+                        [
+                            'id' => '999999',
+                            'type' => 'dummies',
+                            'attributes' => [
+                                'title' => 'dummy object',
+                            ],
+                        ],
                         [
                             'id' => 'af829cbb-c570-4282-94c3-782cf315983a',
                             'type' => 'streams',


### PR DESCRIPTION
This fixes `ApiFormatterComponent::extractFromIncluded` when included data is a 1-1 relationship (i.e. response from `GET /media?include=object`).