### PR TITLE
Twig function element in BeditaTwigExtension

### DIFF
--- a/src/View/Twig/BeditaTwigExtension.php
+++ b/src/View/Twig/BeditaTwigExtension.php
@@ -13,6 +13,7 @@
 namespace BEdita\WebTools\View\Twig;
 
 use Cake\Core\Configure;
+use Twig\TwigFunction;
 
 /**
  * BEdita Twig extension class.
@@ -42,6 +43,14 @@ class BeditaTwigExtension extends \Twig_Extension
 
                 return;
             }),
+            // from https://github.com/cakephp/twig-view/blob/1.x/src/Twig/Extension/ViewExtension.php#L43
+            new TwigFunction(
+                'element',
+                function ($context, string $name, array $data = [], array $options = []) {
+                    return $context['_view']->element($name, $data, $options);
+                },
+                ['needs_context' => true, 'is_safe' => ['all']]
+            ),
         ];
     }
 

--- a/tests/TestCase/View/Twig/BeditaTwigExtensionTest.php
+++ b/tests/TestCase/View/Twig/BeditaTwigExtensionTest.php
@@ -12,8 +12,8 @@
  */
 namespace BEdita\WebTools\Test\TestCase\View\Twig;
 
-use BEdita\WebTools\View\Twig\BeditaTwigExtension;
 use BEdita\WebTools\View\TwigView;
+use BEdita\WebTools\View\Twig\BeditaTwigExtension;
 use Cake\TestSuite\TestCase;
 
 /**

--- a/tests/TestCase/View/Twig/BeditaTwigExtensionTest.php
+++ b/tests/TestCase/View/Twig/BeditaTwigExtensionTest.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2022 Atlas Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+namespace BEdita\WebTools\Test\TestCase\View\Twig;
+
+use BEdita\WebTools\View\Twig\BeditaTwigExtension;
+use Cake\TestSuite\TestCase;
+
+/**
+ * {@see BEdita\WebTools\View\Twig\BeditaTwigExtension} Test Case
+ *
+ * @coversDefaultClass \BEdita\WebTools\View\Twig\BeditaTwigExtension
+ */
+class BeditaTwigExtensionTest extends TestCase
+{
+    /**
+     * Test `getName` method
+     *
+     * @return void
+     * @covers ::getName()
+     * @covers ::getFunctions()
+     */
+    public function testExtension(): void
+    {
+        $extension = new BeditaTwigExtension();
+        $expected = 'bedita';
+        $actual = $extension->getName();
+        static::assertSame($expected, $actual);
+
+        $expected = 3;
+        $actual = count($extension->getFunctions());
+        static::assertSame($expected, $actual);
+    }
+}

--- a/tests/TestCase/View/Twig/BeditaTwigExtensionTest.php
+++ b/tests/TestCase/View/Twig/BeditaTwigExtensionTest.php
@@ -23,11 +23,12 @@ use Cake\TestSuite\TestCase;
 class BeditaTwigExtensionTest extends TestCase
 {
     /**
-     * Test `getName` method
+     * Test all methods
      *
      * @return void
      * @covers ::getName()
      * @covers ::getFunctions()
+     * @covers ::getFilters()
      */
     public function testExtension(): void
     {
@@ -38,6 +39,10 @@ class BeditaTwigExtensionTest extends TestCase
 
         $expected = 3;
         $actual = count($extension->getFunctions());
+        static::assertSame($expected, $actual);
+
+        $expected = 3;
+        $actual = count($extension->getFilters());
         static::assertSame($expected, $actual);
     }
 }

--- a/tests/TestCase/View/TwigViewTest.php
+++ b/tests/TestCase/View/TwigViewTest.php
@@ -13,7 +13,6 @@
 namespace BEdita\WebTools\Test\TestCase\View;
 
 use BEdita\WebTools\View\TwigView;
-use Cake\Core\Configure;
 use Cake\TestSuite\TestCase;
 
 /**


### PR DESCRIPTION
This adds function `element` to `BeditaTwigExtension` in 1.x (like https://github.com/cakephp/twig-view/blob/1.x/src/Twig/Extension/ViewExtension.php#L43).

This should help apps that use webtools 1.x to refactor `{% element ...%}` to `{{ element(...) }}` (road to cakephp 4).



