### PR TITLE
Add phpstan/phpstan 1.5 + fix php workflow

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -74,7 +74,7 @@ jobs:
         uses: 'shivammathur/setup-php@v2'
         with:
           php-version: '${{ matrix.php-version }}'
-          tools: 'composer:v2, phpstan'
+          tools: 'composer:v2'
           extensions: 'mbstring, intl'
           coverage: 'none'
 
@@ -96,7 +96,7 @@ jobs:
 
       - name: 'Run PHP STAN'
         run: |
-          phpstan analyse --no-progress src
+          vendor/bin/phpstan analyse --no-progress --error-format=github
 
   unit:
     name: 'Run unit tests'

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Project files #
 #################
 /composer.lock
+/phpstan.neon
 /phpunit.xml
 /coverage
 /vendor

--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
         "cakephp/authorization": "^2.2",
         "cakephp/cakephp-codesniffer": "~4.2.0",
         "josegonzalez/dotenv": "^3.2",
+        "phpstan/phpstan": "^1.5",
         "phpunit/phpunit": "^8.0|^9.0"
     },
     "suggest": {

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,7 @@
+parameters:
+  bootstrapFiles:
+    - tests/bootstrap.php
+  paths:
+    - src
+    - tests
+  level: 0

--- a/tests/TestCase/View/Helper/HtmlHelperTest.php
+++ b/tests/TestCase/View/Helper/HtmlHelperTest.php
@@ -85,13 +85,13 @@ class HtmlHelperTest extends TestCase
                 null,
                 'My Controller',
             ],
-            'title from controller, action' => [
+            'title from controller, action 1' => [
                 'my_controller',
                 'my_action',
                 null,
                 'My Controller - My Action',
             ],
-            'title from controller, action' => [
+            'title from controller, action 2' => [
                 'my_controller',
                 'my_action',
                 'My title',
@@ -251,11 +251,11 @@ class HtmlHelperTest extends TestCase
     public function metaGeneratorProvider(): array
     {
         return [
-            'empty project and version' => [
+            'empty project and version 1' => [
                 [],
                 '',
             ],
-            'empty project and version' => [
+            'empty project and version 2' => [
                 [
                     'name' => '',
                     'version' => '',


### PR DESCRIPTION
This updates `php` workflow, so that `phpstan` dependency version is used (instead of downloading it with composer, during CI).

This activity in bedita started with https://github.com/bedita/bedita/pull/1889