### PR TITLE
External OAuth2 provider authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,3 +303,73 @@ public function getAuthorizationService(ServerRequestInterface $request): Author
 
     return new AuthorizationService($mapResolver);
 }
+```
+
+## OAuth2 providers
+
+If you are using the `OAuth2Authenticator` and `OAuth2Identifier` classes you must pass the supported OAuth2 providers configuration when you are loadnig this classes in the authentication service.
+Here a brief example:
+
+```php
+
+    $service = new AuthenticationService();
+
+    $providers = (array)Configure::read('OAuth2Providers');
+    $service->loadIdentifier('BEdita/WebTools.OAuth2', compact('providers') + [
+        'autoSignup' => true,
+        'signupRoles' => ['customer'],
+    ]);
+    $service->loadAuthenticator('BEdita/WebTools.OAuth2', compact('providers') + [
+        'redirect' => ['_name' => 'login:oauth2'],
+    ]);
+```
+
+It is recommended to use a configuration key like `OAuth2Providers` to store the provider information, anyway you must pass providers settings array using the `providers` key.
+Other configuration are:
+
+* (`OAuth2Authenticator`) `'redirect'` - default `['_name' => 'login']`, redirect url route specified as named array
+* (`OAuth2Identifier`) `autoSignup` - default `false`, set to `true` if you want an automatic signup to be performed if login fails
+* (`OAuth2Identifier`) `'signupRoles'` - default `[]`, user roles to use during the signup process, used only if `autoSignup` is `true`
+
+### OAuth2 providers structure
+
+The providers configuration structure is in the following example.
+Here a single `google` provider is defined.
+Mandatory configuration keys are `class`, `setup`, `options` and `map` explained below.
+Each provider key must match the `auth_provider` name defined and configured in BEdita API.
+
+```php
+
+    'google' => [
+        // OAuth2 class name, must be a supported provider of `league/oauth2-client`
+        // see https://oauth2-client.thephpleague.com/providers/league/ official or third-party
+        'class' => '\League\OAuth2\Client\Provider\Google',
+
+        // Provider class setup parameters, normally this includes `clientId` and `clientSecret` keys
+        // Other parameters like 'redirectUri' will be added dynamically
+        'setup' => [
+            'clientId' => '####',
+            'clientSecret' => '####',
+        ],
+
+        // Provider authorization options, specify the user information scope that you want to read
+        // `'scope'` array will vary between providers, please read the oauth2-client documentation.
+        'options' => [
+            'scope' => ['https://www.googleapis.com/auth/userinfo.email'],
+        ],
+
+        // Map BEdita user fields with auth provider data path, using dot notation like 'user.id'
+        // In this array keys are BEdita fields, and values are paths to extract the desired item from the provider response
+        // only `'provider_username'` is mandatory, to uniquely identify the user in the provider context
+        // other fields could be used during signup
+        'map' => [
+            'provider_username' => 'sub',
+            'username' => 'email',
+            'email' => 'email',
+            'name' => 'given_name',
+            'surname' => 'family_name',
+        ],
+    ],
+```
+
+For a brief OAuth2 providers reference have a look at the [OAuth2 providers configuration wiki page](https://github.com/bedita/web-tools/wiki/OAuth2-providers-configurations)

--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ public function getAuthorizationService(ServerRequestInterface $request): Author
 
 ## OAuth2 providers
 
-If you are using the `OAuth2Authenticator` and `OAuth2Identifier` classes you must pass the supported OAuth2 providers configuration when you are loadnig this classes in the authentication service.
+If you are using the `OAuth2Authenticator` and `OAuth2Identifier` classes you must pass the supported OAuth2 providers configuration when you are loading this classes in the authentication service.
 Here a brief example:
 
 ```php

--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
         "cakephp/authentication": "^2.9",
         "cakephp/authorization": "^2.2",
         "cakephp/cakephp-codesniffer": "~4.2.0",
+        "league/oauth2-client": "^2.6",
         "josegonzalez/dotenv": "^3.2",
         "phpstan/phpstan": "^1.5",
         "phpunit/phpunit": "^8.0|^9.0"

--- a/composer.json
+++ b/composer.json
@@ -58,10 +58,7 @@
         "cs-check": "vendor/bin/phpcs --colors -p --standard=vendor/cakephp/cakephp-codesniffer/CakePHP ./src ./tests",
         "cs-fix": "vendor/bin/phpcbf --colors --standard=vendor/cakephp/cakephp-codesniffer/CakePHP ./src ./tests",
         "test": "vendor/bin/phpunit --colors=always",
-        "update-dev": [
-            "@composer update",
-            "@cs-setup"
-        ]
+        "stan": "vendor/bin/phpstan analyse"
     },
     "prefer-stable": true,
     "config": {

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "cakephp/twig-view": "^1.2.0"
     },
     "require-dev": {
-        "cakephp/authentication": "^2.5",
+        "cakephp/authentication": "^2.9",
         "cakephp/authorization": "^2.2",
         "cakephp/cakephp-codesniffer": "~4.2.0",
         "josegonzalez/dotenv": "^3.2",
@@ -34,7 +34,7 @@
         "phpunit/phpunit": "^8.0|^9.0"
     },
     "suggest": {
-        "cakephp/authentication": "^2.5 To use \"ApiIdentifier\", \"Identity\", \"IdentityHelper\" and other authentication features",
+        "cakephp/authentication": "^2.9 To use \"ApiIdentifier\", \"Identity\", \"IdentityHelper\" and other authentication features",
         "cakephp/authorization": "^2.2 To use \"RequestPolicy\" and other authorization features"
     },
     "autoload": {

--- a/src/Authenticator/OAuth2Authenticator.php
+++ b/src/Authenticator/OAuth2Authenticator.php
@@ -179,6 +179,6 @@ class OAuth2Authenticator extends AbstractAuthenticator
             $redirectUri['?'] = ['redirect' => $queryRedirectUrl];
         }
 
-        return call_user_func($this->getConfig('urlResolver'), [$redirectUri]);
+        return call_user_func($this->getConfig('urlResolver'), $redirectUri);
     }
 }

--- a/src/Authenticator/OAuth2Authenticator.php
+++ b/src/Authenticator/OAuth2Authenticator.php
@@ -1,0 +1,144 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2022 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+namespace BEdita\WebTools\Authenticator;
+
+use Authentication\Authenticator\AbstractAuthenticator;
+use Authentication\Authenticator\Result;
+use Authentication\Authenticator\ResultInterface;
+use Cake\Core\Configure;
+use Cake\Http\Exception\BadRequestException;
+use Cake\Log\LogTrait;
+use Cake\Routing\Router;
+use Cake\Utility\Hash;
+use Psr\Http\Message\ServerRequestInterface;
+
+class OAuth2Authenticator extends AbstractAuthenticator
+{
+    use LogTrait;
+
+    /**
+     * External Auth provider
+     *
+     * @var \League\OAuth2\Client\Provider\AbstractProvider
+     */
+    protected $provider = null;
+
+    /**
+     * @inheritDoc
+     */
+    protected $_defaultConfig = [
+        'sessionKey' => 'oauth2state',
+        'redirect' => ['_name' => 'login'],
+    ];
+
+    /**
+     * @inheritDoc
+     */
+    public function authenticate(ServerRequestInterface $request): ResultInterface
+    {
+        // extract provider from request
+        $provider = basename($request->getUri()->getPath());
+
+        $connect = $this->providerConnect($provider, $request);
+        if (!empty($connect['authUrl'])) {
+            return new Result($connect, Result::SUCCESS);
+        }
+
+        $usernameField = (string)Configure::read(sprintf('OAuth2Providers.%s.map.provider_username', $provider));
+        $data = [
+            'auth_provider' => $provider,
+            'provider_username' => Hash::get($connect, sprintf('user.%s', $usernameField)),
+            'access_token' => Hash::get($connect, 'token.access_token'),
+            'provider_userdata' => (array)Hash::get($connect, 'user'),
+        ];
+        $user = $this->_identifier->identify($data);
+
+        if (empty($user)) {
+            return new Result(null, Result::FAILURE_IDENTITY_NOT_FOUND, $this->_identifier->getErrors());
+        }
+
+        return new Result($user, Result::SUCCESS);
+    }
+
+    /**
+     * Perform Oauth2 connect action on Auth Provider.
+     *
+     * @param string $provider Provider name.
+     * @param \Psr\Http\Message\ServerRequestInterface $request Request to get authentication information from.
+     * @return array;
+     * @throws \Cake\Http\Exception\BadRequestException
+     */
+    protected function providerConnect(string $provider, ServerRequestInterface $request): array
+    {
+        $this->initProvider($provider, $request);
+
+        $query = $request->getQueryParams();
+        $sessionKey = $this->getConfig('sessionKey');
+        /** @var \Cake\Http\Session $session */
+        $session = $request->getAttribute('session');
+
+        if (!isset($query['code'])) {
+            // If we don't have an authorization code then get one
+            $options = (array)Configure::read(sprintf('OAuth2Providers.%s.options', $provider));
+            $authUrl = $this->provider->getAuthorizationUrl($options);
+            $session->write($sessionKey, $this->provider->getState());
+
+            return compact('authUrl');
+        }
+
+        // Check given state against previously stored one to mitigate CSRF attack
+        if (empty($query['state']) || ($query['state'] !== $session->read($sessionKey))) {
+            $session->delete($sessionKey);
+            throw new BadRequestException('Invalid state');
+        }
+
+        // Try to get an access token (using the authorization code grant)
+        /** @var \League\OAuth2\Client\Token\AccessToken $token */
+        $token = $this->provider->getAccessToken('authorization_code', ['code' => $query['code']]);
+        // We got an access token, let's now get the user's details
+        $user = $this->provider->getResourceOwner($token)->toArray();
+        $token = $token->jsonSerialize();
+
+        return compact('token', 'user');
+    }
+
+    /**
+     * Init external auth provider via configuration
+     *
+     * @param string $provider Provider name.
+     * @param \Psr\Http\Message\ServerRequestInterface $request Request to get authentication information from.
+     * @return void
+     */
+    protected function initProvider(string $provider, ServerRequestInterface $request): void
+    {
+        $providerConf = (array)Configure::read(sprintf('OAuth2Providers.%s', $provider));
+        if (empty($providerConf['class']) || empty($providerConf['setup'])) {
+            throw new BadRequestException('Invalid auth provider ' . $provider);
+        }
+
+        $redirectUri = (array)$this->getConfig('redirect') + compact('provider');
+        $query = $request->getQueryParams();
+        $queryRedirectUrl = Hash::get($query, 'redirect');
+        if (!empty($queryRedirectUrl)) {
+            $redirectUri['?'] = ['redirect' => $queryRedirectUrl];
+        }
+        $redirectUri = Router::url($redirectUri, true);
+        $this->log(sprintf('Creating %s provider with redirect url %s', $provider, $redirectUri), 'info');
+        $setup = (array)Hash::get($providerConf, 'setup') + compact('redirectUri');
+
+        $class = Hash::get($providerConf, 'class');
+        $this->provider = new $class($setup);
+    }
+}

--- a/src/Authenticator/OAuth2Authenticator.php
+++ b/src/Authenticator/OAuth2Authenticator.php
@@ -48,12 +48,20 @@ class OAuth2Authenticator extends AbstractAuthenticator
     public const AUTH_URL_KEY = 'authUrl';
 
     /**
-     * @inheritDoc
+     * Configuration options
+     *
+     * - `sessionKey` - Session key to store the request attribute which holds the identity.
+     * - `redirect` - redirect URL in array format as named route,
+     *                  used to redirect from the provider to the application
+     * - `providers` - configured OAuth2 providers, see https://github.com/bedita/web-tools/wiki/OAuth2-providers-configurations
+     * - `urlResolver` - callback to resolve redirect URL, defaults to ` Router::url($route, true)`
+     *
+     * @var array
      */
     protected $_defaultConfig = [
         'sessionKey' => 'oauth2state',
-        'redirect' => ['_name' => 'login'], // named route used to redirect
-        'providers' => [], // configured OAuth2 providers
+        'redirect' => ['_name' => 'login'],
+        'providers' => [],
         'urlResolver' => null,
     ];
 

--- a/src/Identifier/OAuth2Identifier.php
+++ b/src/Identifier/OAuth2Identifier.php
@@ -18,7 +18,6 @@ use ArrayObject;
 use Authentication\Identifier\AbstractIdentifier;
 use BEdita\SDK\BEditaClientException;
 use BEdita\WebTools\ApiClientProvider;
-use Cake\Core\Configure;
 use Cake\Log\LogTrait;
 use Cake\Utility\Hash;
 
@@ -38,6 +37,7 @@ class OAuth2Identifier extends AbstractIdentifier
         ],
         'autoSignup' => false,
         'signupRoles' => [],
+        'providers' => [], // configured OAuth2 providers
     ];
 
     /**
@@ -111,7 +111,7 @@ class OAuth2Identifier extends AbstractIdentifier
      */
     protected function signupData(array $credentials): array
     {
-        $user = (array)Configure::read(sprintf('OAuth2Providers.%s.map', $credentials['auth_provider']));
+        $user = (array)$this->getConfig(sprintf('providers.%s.map', $credentials['auth_provider']));
         foreach ($user as $key => $value) {
             $user[$key] = Hash::get($credentials, sprintf('provider_userdata.%s', $value));
         }

--- a/src/Identifier/OAuth2Identifier.php
+++ b/src/Identifier/OAuth2Identifier.php
@@ -28,6 +28,16 @@ class OAuth2Identifier extends AbstractIdentifier
 {
     use LogTrait;
 
+    /**
+     * Configuration options
+     *
+     * - `fields` - Fields used in `/auth` endpoint using and external auth provider.
+     * - `autoSignup` - flag indicating whether `/signup` should be invoked automatically in case of authentication failure.
+     * - `signupRoles` - array of roles to use in `/signup` if `autoSignup` is set to `true`.
+     * - `providers` - configured OAuth2 providers, see https://github.com/bedita/web-tools/wiki/OAuth2-providers-configurations
+     *
+     * @var array
+     */
     protected $_defaultConfig = [
         'fields' => [
             'auth_provider' => 'auth_provider',

--- a/src/Identifier/OAuth2Identifier.php
+++ b/src/Identifier/OAuth2Identifier.php
@@ -1,0 +1,122 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2022 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+namespace BEdita\WebTools\Identifier;
+
+use ArrayObject;
+use Authentication\Identifier\AbstractIdentifier;
+use BEdita\SDK\BEditaClientException;
+use BEdita\WebTools\ApiClientProvider;
+use Cake\Core\Configure;
+use Cake\Log\LogTrait;
+use Cake\Utility\Hash;
+
+/**
+ * Identifies authentication credentials through an OAuth2 external provider.
+ */
+class OAuth2Identifier extends AbstractIdentifier
+{
+    use LogTrait;
+
+    protected $_defaultConfig = [
+        'fields' => [
+            'auth_provider' => 'auth_provider',
+            'provider_username' => 'provider_username',
+            'access_token' => 'access_token',
+            'provider_userdata' => 'provider_userdata',
+        ],
+        'autoSignup' => false,
+        'signupRoles' => [],
+    ];
+
+    /**
+     * @inheritDoc
+     */
+    public function identify(array $credentials)
+    {
+        try {
+            $result = $this->externalAuth($credentials);
+        } catch (BEditaClientException $ex) {
+            $this->log($ex->getMessage(), 'debug');
+
+            if (!$this->getConfig('autoSignup') || $ex->getCode() !== 401) {
+                return null;
+            }
+
+            return $this->signup($credentials);
+        }
+
+        return $result;
+    }
+
+    /**
+     * Perform external login via `/auth`.
+     *
+     * @param array $credentials Identifier credentials
+     * @return \ArrayObject
+     */
+    protected function externalAuth(array $credentials): ArrayObject
+    {
+        $apiClient = ApiClientProvider::getApiClient();
+        $result = $apiClient->post('/auth', json_encode($credentials), ['Content-Type' => 'application/json']);
+        $tokens = $result['meta'];
+        $result = $apiClient->get('/auth/user', null, ['Authorization' => sprintf('Bearer %s', $tokens['jwt'])]);
+
+        return new ArrayObject($result['data']
+            + compact('tokens')
+            + Hash::combine($result, 'included.{n}.attributes.name', 'included.{n}.id', 'included.{n}.type'));
+    }
+
+    /**
+     * Perform OAuth2 signup and login after signup.
+     *
+     * @param array $credentials Identifier credentials
+     * @return \ArrayObject|null;
+     */
+    protected function signup(array $credentials): ?ArrayObject
+    {
+        $data = $this->signupData($credentials);
+        try {
+            $apiClient = ApiClientProvider::getApiClient();
+            $apiClient->setupTokens([]);
+            $apiClient->post('/signup', json_encode($data), ['Content-Type' => 'application/json']);
+            // login after signup
+            $user = $this->externalAuth($credentials);
+        } catch (BEditaClientException $ex) {
+            $this->log($ex->getMessage(), 'warning');
+            $this->log(json_encode($ex->getAttributes()), 'warning');
+
+            return null;
+        }
+
+        return $user;
+    }
+
+    /**
+     * Signup data from OAuth2 provider user data.
+     *
+     * @param array $credentials Identifier credentials
+     * @return array
+     */
+    protected function signupData(array $credentials): array
+    {
+        $user = (array)Configure::read(sprintf('OAuth2Providers.%s.map', $credentials['auth_provider']));
+        foreach ($user as $key => $value) {
+            $user[$key] = Hash::get($credentials, sprintf('provider_userdata.%s', $value));
+        }
+        $roles = (array)$this->getConfig('signupRoles');
+
+        return array_filter($user + $credentials + compact('roles'));
+    }
+}

--- a/src/Middleware/OAuth2Middleware.php
+++ b/src/Middleware/OAuth2Middleware.php
@@ -1,0 +1,47 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2022 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+namespace BEdita\WebTools\Middleware;
+
+use Authentication\Authenticator\Result;
+use Cake\Utility\Hash;
+use Laminas\Diactoros\Response\RedirectResponse;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * Middleware to handle OAuth2 flow.
+ */
+class OAuth2Middleware implements MiddlewareInterface
+{
+    /**
+     * @inheritDoc
+     */
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        $result = $request->getAttribute('authenticationResult');
+        if (empty($result) || !$result instanceof Result || !is_array($result->getData())) {
+            return $handler->handle($request);
+        }
+
+        $authUrl = Hash::get($result->getData(), 'authUrl');
+        if (empty($authUrl)) {
+            return $handler->handle($request);
+        }
+
+        return new RedirectResponse($authUrl);
+    }
+}

--- a/src/Middleware/OAuth2Middleware.php
+++ b/src/Middleware/OAuth2Middleware.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace BEdita\WebTools\Middleware;
 
 use Authentication\Authenticator\Result;
+use BEdita\WebTools\Authenticator\OAuth2Authenticator;
 use Cake\Utility\Hash;
 use Laminas\Diactoros\Response\RedirectResponse;
 use Psr\Http\Message\ResponseInterface;
@@ -37,7 +38,7 @@ class OAuth2Middleware implements MiddlewareInterface
             return $handler->handle($request);
         }
 
-        $authUrl = Hash::get($result->getData(), 'authUrl');
+        $authUrl = Hash::get($result->getData(), OAuth2Authenticator::AUTH_URL_KEY);
         if (empty($authUrl)) {
             return $handler->handle($request);
         }

--- a/tests/TestCase/Authenticator/OAuth2AuthenticatorTest.php
+++ b/tests/TestCase/Authenticator/OAuth2AuthenticatorTest.php
@@ -1,0 +1,186 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2022 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\WebTools\Test\TestCase\Authenticator;
+
+use Authentication\Authenticator\Result;
+use Authentication\Identifier\IdentifierInterface;
+use BEdita\WebTools\Authenticator\OAuth2Authenticator;
+use Cake\Http\Exception\BadRequestException;
+use Cake\Http\ServerRequest;
+use Cake\Http\Session;
+use Cake\TestSuite\TestCase;
+use Cake\Utility\Hash;
+
+/**
+ * {@see \BEdita\WebTools\Authenticator\OAuth2Authenticator} Test Case
+ *
+ * @coversDefaultClass \BEdita\WebTools\Authenticator\OAuth2Authenticator
+ */
+class OAuth2AuthenticatorTest extends TestCase
+{
+    /**
+     * Data provider for `testAuthenticate` test case.
+     *
+     * @return array
+     */
+    public function authenticateProvider(): array
+    {
+        return [
+            'bad provider' => [
+                new BadRequestException('Invalid auth provider gustavo'),
+                [
+                    'url' => '/ext/login/gustavo',
+                ],
+            ],
+            'auth url ok' => [
+                [
+                    'status' => Result::SUCCESS,
+                ],
+                [
+                    'url' => '/ext/login/gustavo',
+                ],
+                [
+                    'urlResolver' => fn () => '',
+                    'providers' => [
+                        'gustavo' => [
+                            'class' => TestProvider::class,
+                            'setup' => [
+                                'clientId' => '',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            'invalid state' => [
+                new BadRequestException('Invalid state'),
+                [
+                    'url' => '/ext/login/gustavo?code=1&state=1',
+                ],
+                [
+                    'urlResolver' => fn () => '',
+                    'providers' => [
+                        'gustavo' => [
+                            'class' => TestProvider::class,
+                            'setup' => [
+                                'clientId' => '',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            'auth ok' => [
+                [
+                    'status' => Result::SUCCESS,
+                ],
+                [
+                    'url' => '/ext/login/gustavo?code=1&state=abc&redirect=here',
+                    'data' => [
+                        'oauth2state' => 'abc',
+                    ],
+                ],
+                [
+                    'urlResolver' => fn () => '',
+                    'providers' => [
+                        'gustavo' => [
+                            'class' => TestProvider::class,
+                            'setup' => [
+                                'clientId' => '',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            'auth fail' => [
+                [
+                    'status' => Result::FAILURE_IDENTITY_NOT_FOUND,
+                ],
+                [
+                    'url' => '/ext/login/gustavo?code=1&state=abc',
+                    'data' => [
+                        'oauth2state' => 'abc',
+                    ],
+                ],
+                [
+                    'urlResolver' => function () {
+                        return '';
+                    },
+                    'providers' => [
+                        'gustavo' => [
+                            'class' => TestProvider::class,
+                            'setup' => [
+                                'clientId' => '',
+                            ],
+                        ],
+                    ],
+                ],
+                [],
+            ],
+        ];
+    }
+
+    /**
+     * Test `authenticate` method
+     *
+     * @param array|\Exception $expected EXpected result.
+     * @param array $config Request configuration.
+     * @param array $authConfig Authenticator configuration.
+     * @param array $identity Identity data.
+     * @return void
+     * @dataProvider authenticateProvider
+     * @covers ::authenticate()
+     * @covers ::providerConnect()
+     * @covers ::initProvider()
+     * @covers ::redirectUri()
+     * @covers ::__construct()
+     */
+    public function testAuthenticate(
+        $expected,
+        array $reqConfig,
+        array $authConfig = [],
+        array $identity = ['id' => 1]
+    ): void {
+        if ($expected instanceof \Exception) {
+            $this->expectException(get_class($expected));
+            $this->expectExceptionCode($expected->getCode());
+            $this->expectExceptionMessage($expected->getMessage());
+        }
+
+        $identifier = new class ($identity) implements IdentifierInterface {
+            public function __construct($identity) {
+                $this->identity = $identity;
+            }
+
+            public function identify(array $credentials)
+            {
+                return $this->identity;
+            }
+
+            public function getErrors(): array
+            {
+                return [];
+            }
+        };
+        $request = new ServerRequest($reqConfig);
+        $session = new Session();
+        $session->write(Hash::get($reqConfig, 'data'));
+        $request = $request->withAttribute('session', $session);
+        $authenticator = new OAuth2Authenticator($identifier, $authConfig);
+        $result = $authenticator->authenticate($request);
+
+        static::assertNotNull($result);
+        static::assertEquals($expected['status'], $result->getStatus());
+    }
+}

--- a/tests/TestCase/Authenticator/OAuth2AuthenticatorTest.php
+++ b/tests/TestCase/Authenticator/OAuth2AuthenticatorTest.php
@@ -159,7 +159,8 @@ class OAuth2AuthenticatorTest extends TestCase
         }
 
         $identifier = new class ($identity) implements IdentifierInterface {
-            public function __construct($identity) {
+            public function __construct($identity)
+            {
                 $this->identity = $identity;
             }
 

--- a/tests/TestCase/Authenticator/OAuth2AuthenticatorTest.php
+++ b/tests/TestCase/Authenticator/OAuth2AuthenticatorTest.php
@@ -159,6 +159,8 @@ class OAuth2AuthenticatorTest extends TestCase
         }
 
         $identifier = new class ($identity) implements IdentifierInterface {
+            protected $identity;
+
             public function __construct($identity)
             {
                 $this->identity = $identity;

--- a/tests/TestCase/Authenticator/TestProvider.php
+++ b/tests/TestCase/Authenticator/TestProvider.php
@@ -1,0 +1,44 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2022 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\WebTools\Test\TestCase\Authenticator;
+
+use League\OAuth2\Client\Provider\GenericProvider;
+use League\OAuth2\Client\Provider\GenericResourceOwner;
+use League\OAuth2\Client\Token\AccessToken;
+
+class TestProvider extends GenericProvider
+{
+    protected function getRequiredOptions()
+    {
+        return [];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getAccessToken($grant, array $options = [])
+    {
+        return new AccessToken(['access_token' => 'test-token']);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getResourceOwner(AccessToken $token)
+    {
+        return new GenericResourceOwner(['1' => '1'], '1');
+    }
+}

--- a/tests/TestCase/Identifier/OAuth2IdentifierTest.php
+++ b/tests/TestCase/Identifier/OAuth2IdentifierTest.php
@@ -1,0 +1,176 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2022 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\WebTools\Test\TestCase\Identifier;
+
+use ArrayObject;
+use BEdita\SDK\BEditaClient;
+use BEdita\SDK\BEditaClientException;
+use BEdita\WebTools\ApiClientProvider;
+use BEdita\WebTools\Identifier\OAuth2Identifier;
+use Cake\TestSuite\TestCase;
+
+/**
+ * {@see \BEdita\WebTools\Identifier\OAuth2Identifier} Test Case
+ *
+ * @coversDefaultClass \BEdita\WebTools\Identifier\OAuth2Identifier
+ */
+class OAuth2IdentifierTest extends TestCase
+{
+    /**
+     * @inheritDoc
+     */
+    public function tearDown(): void
+    {
+        parent::tearDown();
+        ApiClientProvider::setApiClient(null);
+    }
+
+    /**
+     * Test `identify` method with successful login.
+     *
+     * @return void
+     * @covers ::identify()
+     * @covers ::externalAuth()
+     */
+    public function testIdentifyOk(): void
+    {
+        $apiClientMock = $this->getMockBuilder(BEditaClient::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['get', 'post'])
+            ->getMock();
+        $apiClientMock->method('post')->willReturn([
+            'meta' => ['jwt' => 'gustavo'],
+        ]);
+        $apiClientMock->method('get')->willReturn([
+            'data' => ['id' => 1],
+        ]);
+
+        $identifier = new OAuth2Identifier();
+        ApiClientProvider::setApiClient($apiClientMock);
+
+        $identity = $identifier->identify([]);
+        $expected = new ArrayObject([
+            'id' => 1,
+            'tokens' => [
+                'jwt' => 'gustavo',
+            ],
+        ]);
+        static::assertEquals($expected, $identity);
+    }
+
+    /**
+     * Test `identify` method with unsuccessful login.
+     *
+     * @return void
+     * @covers ::identify()
+     * @covers ::externalAuth()
+     */
+    public function testNullIdentify(): void
+    {
+        $apiClientMock = $this->getMockBuilder(BEditaClient::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['post'])
+            ->getMock();
+        $apiClientMock->method('post')->willThrowException(
+            new BEditaClientException('', 404)
+        );
+
+        $identifier = new OAuth2Identifier();
+        ApiClientProvider::setApiClient($apiClientMock);
+
+        $identity = $identifier->identify([]);
+        static::assertNull($identity);
+    }
+
+    /**
+     * Test `identify` method with successful signup.
+     *
+     * @return void
+     * @covers ::identify()
+     * @covers ::signup()
+     * @covers ::signupData()
+     */
+    public function testOkSignup(): void
+    {
+        $apiClientMock = $this->getMockBuilder(BEditaClient::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['get', 'post'])
+            ->getMock();
+        $count = 0;
+        $apiClientMock->method('post')->willReturnCallback(
+            function () use (&$count) {
+                if ($count == 0) {
+                    $count++;
+                    throw new BEditaClientException('', 401);
+                }
+
+                return ['meta' => ['jwt' => 'gustavo']];
+            }
+        );
+        $apiClientMock->method('get')->willReturn([
+                'data' => ['id' => 1],
+        ]);
+
+        $identifier = new OAuth2Identifier([
+            'autoSignup' => true,
+            'providers' => [
+                'gustavo' => [
+                    'map' => ['id' => 'id'],
+                ],
+            ],
+        ]);
+        ApiClientProvider::setApiClient($apiClientMock);
+
+        $identity = $identifier->identify(['auth_provider' => 'gustavo']);
+        $expected = new ArrayObject([
+            'id' => 1,
+            'tokens' => [
+                'jwt' => 'gustavo',
+            ],
+        ]);
+        static::assertEquals($expected, $identity);
+    }
+
+    /**
+     * Test `identify` method with unsuccessful signup.
+     *
+     * @return void
+     * @covers ::identify()
+     * @covers ::signup()
+     * @covers ::signupData()
+     */
+    public function testFailSignup(): void
+    {
+        $apiClientMock = $this->getMockBuilder(BEditaClient::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['post'])
+            ->getMock();
+        $apiClientMock->method('post')->willThrowException(new BEditaClientException('', 401));
+
+        $identifier = new OAuth2Identifier([
+            'autoSignup' => true,
+            'providers' => [
+                'gustavo' => [
+                    'map' => ['id' => 'id'],
+                ],
+            ],
+        ]);
+        ApiClientProvider::setApiClient($apiClientMock);
+
+        $identity = $identifier->identify(['auth_provider' => 'gustavo']);
+        static::assertNull($identity);
+    }
+}

--- a/tests/TestCase/Middleware/OAuth2MiddlewareTest.php
+++ b/tests/TestCase/Middleware/OAuth2MiddlewareTest.php
@@ -1,0 +1,111 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2022 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+namespace BEdita\WebTools\Test\TestCase\Middleware;
+
+use Authentication\Authenticator\Result;
+use Authentication\Authenticator\ResultInterface;
+use BEdita\WebTools\Authenticator\OAuth2Authenticator;
+use BEdita\WebTools\Middleware\OAuth2Middleware;
+use Cake\Http\Response;
+use Cake\Http\ServerRequest;
+use Cake\TestSuite\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * {@see BEdita\WebTools\Middleware\OAuth2Middleware} Test Case
+ *
+ * @coversDefaultClass BEdita\WebTools\Middleware\OAuth2Middleware
+ */
+class OAuth2MiddlewareTest extends TestCase
+{
+    /**
+     * Request Handler class
+     *
+     * @var \Psr\Http\Server\RequestHandlerInterface
+     */
+    protected $handler;
+
+    /**
+     * @inheritDoc
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->handler = new class () implements RequestHandlerInterface {
+            public function handle(ServerRequestInterface $request): ResponseInterface
+            {
+                return new Response(['status' => 204]);
+            }
+        };
+    }
+
+    /**
+     * Test `process` with no authentication result.
+     *
+     * @return void
+     * @covers ::process()
+     */
+    public function testNoResult(): void
+    {
+        $request = new ServerRequest();
+        $middleware = new OAuth2Middleware();
+        $response = $middleware->process($request, $this->handler);
+
+        static::assertInstanceOf(Response::class, $response);
+        static::assertEquals(204, $response->getStatusCode());
+    }
+
+    /**
+     * Test `process` with authentication result but without `authUrl`.
+     *
+     * @return void
+     * @covers ::process()
+     */
+    public function testResultNoAuth(): void
+    {
+        $request = new ServerRequest();
+        $result = new Result(['key' => 'value'], ResultInterface::SUCCESS);
+        $request = $request->withAttribute('authenticationResult', $result);
+
+        $middleware = new OAuth2Middleware();
+        $response = $middleware->process($request, $this->handler);
+
+        static::assertInstanceOf(Response::class, $response);
+        static::assertEquals(204, $response->getStatusCode());
+    }
+
+    /**
+     * Test `process` with authentication with `authUrl`.
+     *
+     * @return void
+     * @covers ::process()
+     */
+    public function testResultAuth(): void
+    {
+        $request = new ServerRequest();
+        $data = [OAuth2Authenticator::AUTH_URL_KEY => 'http://example.com'];
+        $result = new Result($data, ResultInterface::SUCCESS);
+        $request = $request->withAttribute('authenticationResult', $result);
+
+        $middleware = new OAuth2Middleware();
+        $response = $middleware->process($request, $this->handler);
+
+        static::assertEquals(302, $response->getStatusCode());
+        static::assertEquals('http://example.com', $response->getHeaderLine('Location'));
+    }
+}


### PR DESCRIPTION
In this PR a basic OAuth2 authentication flow has been implemented using `cakephp/authentication` plugin and BEdita4/5 API.

Three new classes have been added:
 * `OAuth2Authenticator` class to extract information from request and from the selected oauth2 authentication provider 
 * `OAuth2Identifier` class to perform login and signup actions via BEdita API 
 * `OAuth2Middleware` class to perform redirect to the oauth2 provider when the authorization URL has been made available in the session
 