### PR TITLE
Use reusable PHP workflows in CI [master, 3.x]

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -14,168 +14,23 @@ on:
 
 jobs:
   cs:
-    name: 'Check coding style'
-    if: "!contains(github.event.commits[0].message, '[skip ci]') && !contains(github.event.commits[0].message, '[ci skip]')"
-    runs-on: 'ubuntu-latest'
-
-    strategy:
-      matrix:
-        php-version: [7.4]
-
-    steps:
-      - name: 'Checkout current revision'
-        uses: 'actions/checkout@v2'
-
-      - name: 'Setup PHP'
-        uses: 'shivammathur/setup-php@v2'
-        with:
-          php-version: '${{ matrix.php-version }}'
-          tools: 'composer:v2'
-          extensions: 'mbstring, intl'
-          coverage: 'none'
-
-      - name: 'Discover Composer cache directory'
-        id: 'cachedir'
-        run: 'echo "::set-output name=path::$(composer global config cache-dir)"'
-
-      - name: 'Share Composer cache across runs'
-        uses: 'actions/cache@v2'
-        with:
-          path: '${{ steps.cachedir.outputs.path }}'
-          key: "composer-${{ github.job }}-${{ hashFiles('**/composer.json') }}"
-          restore-keys: |
-            composer-${{ github.job }}-
-            composer-
-
-      - name: 'Install dependencies with Composer'
-        run: 'composer install --prefer-dist --no-interaction'
-
-      - name: 'Run PHP CodeSniffer'
-        run: |
-          vendor/bin/phpcs -n -p --extensions=php \
-            --standard=vendor/cakephp/cakephp-codesniffer/CakePHP \
-            ./config ./src ./tests
+    uses: bedita/github-workflows/.github/workflows/php-cs.yml@v1
+    with:
+      php_versions: '["7.4", "8.0", "8.1"]'
 
   stan:
-    name: 'Static code analyzer'
-    if: "!contains(github.event.commits[0].message, '[skip ci]') && !contains(github.event.commits[0].message, '[ci skip]')"
-    runs-on: 'ubuntu-latest'
-    continue-on-error: true
+    uses: bedita/github-workflows/.github/workflows/php-stan.yml@v1
+    with:
+      php_versions: '["7.4", "8.0", "8.1"]'
 
-    strategy:
-      matrix:
-        php-version: [7.4, 8.0, 8.1]
+  unit-4:
+    uses: bedita/github-workflows/.github/workflows/php-unit.yml@v1
+    with:
+      php_versions: '["7.4","8.0","8.1"]'
+      bedita_version: '4.7.1'
 
-    steps:
-      - name: 'Checkout current revision'
-        uses: 'actions/checkout@v2'
-
-      - name: 'Setup PHP'
-        uses: 'shivammathur/setup-php@v2'
-        with:
-          php-version: '${{ matrix.php-version }}'
-          tools: 'composer:v2'
-          extensions: 'mbstring, intl'
-          coverage: 'none'
-
-      - name: 'Discover Composer cache directory'
-        id: 'cachedir'
-        run: 'echo "::set-output name=path::$(composer global config cache-dir)"'
-
-      - name: 'Share Composer cache across runs'
-        uses: 'actions/cache@v2'
-        with:
-          path: '${{ steps.cachedir.outputs.path }}'
-          key: "composer-${{ github.job }}-${{ hashFiles('**/composer.json') }}"
-          restore-keys: |
-            composer-${{ github.job }}-
-            composer-
-
-      - name: 'Install dependencies with Composer'
-        run: 'composer install --prefer-dist --no-interaction'
-
-      - name: 'Run PHP STAN'
-        run: |
-          vendor/bin/phpstan analyse --no-progress --error-format=github
-
-  unit:
-    name: 'Run unit tests'
-    if: "!contains(github.event.commits[0].message, '[skip ci]') && !contains(github.event.commits[0].message, '[ci skip]')"
-    runs-on: 'ubuntu-latest'
-    env:
-      BEDITA_API_KEY: 12345
-      BEDITA_API: http://127.0.0.1:8080
-      BEDITA_ADMIN_USR: admin
-      BEDITA_ADMIN_PWD: admin
-      BEDITA_DOCKER_IMG: bedita/bedita:4.7.0
-
-    strategy:
-      matrix:
-        php-version: [7.4, 8.0, 8.1]
-
-    steps:
-      - name: 'Checkout current revision'
-        uses: 'actions/checkout@v2'
-
-      - name: 'Composer config GH token if available'
-        run: 'if [ -n "$GH_TOKEN" ]; then composer config github-oauth.github.com ${GH_TOKEN}; fi'
-
-      - name: 'Docker pull bedita image'
-        run: 'docker pull ${BEDITA_DOCKER_IMG}'
-
-      - name: 'Docker inspect bedita image'
-        run: 'docker inspect ${BEDITA_DOCKER_IMG}'
-
-      - name: 'Docker run bedita image'
-        run: 'docker run --name api -d -p 127.0.0.1:8080:80 --env BEDITA_API_KEY=${BEDITA_API_KEY} --env BEDITA_ADMIN_USR=${BEDITA_ADMIN_USR} --env BEDITA_ADMIN_PWD=${BEDITA_ADMIN_PWD} ${BEDITA_DOCKER_IMG}'
-
-      - name: 'Wait for 10'
-        run: 'sleep 10'
-
-      - name: 'Docker ps - show all containers'
-        run: 'docker ps -a'
-
-      - name: 'Setup PHP'
-        uses: 'shivammathur/setup-php@v2'
-        with:
-          php-version: '${{ matrix.php-version }}'
-          tools: 'composer:v2'
-          extensions: 'mbstring, intl'
-
-      - name: 'Discover Composer cache directory'
-        id: 'cachedir'
-        run: 'echo "::set-output name=path::$(composer global config cache-dir)"'
-
-      - name: 'Share Composer cache across runs'
-        uses: 'actions/cache@v2'
-        with:
-          path: '${{ steps.cachedir.outputs.path }}'
-          key: "composer-${{ matrix.php-version }}-${{ hashFiles('**/composer.json') }}"
-          restore-keys: |
-            composer-${{ matrix.php-version }}-
-            composer-
-
-      - name: 'Install dependencies with Composer'
-        run: 'composer install --prefer-dist --no-interaction'
-
-      - name: 'Run PHPUnit with coverage'
-        run: 'vendor/bin/phpunit --coverage-clover=clover.xml'
-
-      - name: Check test coverage
-        id: test-coverage
-        uses: johanvanhelden/gha-clover-test-coverage-check@v1
-        with:
-          percentage: '85'
-          filename: 'clover.xml'
-
-      - name: 'Export coverage results'
-        uses: 'codecov/codecov-action@v1'
-        with:
-          file: './clover.xml'
-          env_vars: PHP_VERSION
-
-      - name: 'Archive code coverage results'
-        uses: 'actions/upload-artifact@v2'
-        with:
-          name: 'PHP ${{ matrix.php }}'
-          path: 'clover.xml'
+  unit-5:
+    uses: bedita/github-workflows/.github/workflows/php-unit.yml@v1
+    with:
+      php_versions: '["7.4","8.0","8.1"]'
+      bedita_version: '5.0.2'


### PR DESCRIPTION
This uses reusable workflows for cs, stan and unit.

Bonus: unit tests on BE5 too.