### PR TITLE
Show JSON error response on `application/json` Accept

### DIFF
--- a/src/Error/ExceptionRenderer.php
+++ b/src/Error/ExceptionRenderer.php
@@ -16,7 +16,8 @@ declare(strict_types=1);
 namespace BEdita\WebTools\Error;
 
 use BEdita\SDK\BEditaClientException;
-use Cake\Error\ExceptionRenderer as CakeExceptionRenderer;
+use Cake\Controller\Controller;
+use Cake\Error\Renderer\WebExceptionRenderer;
 use Cake\Http\Response;
 use Cake\Log\LogTrait;
 
@@ -24,7 +25,7 @@ use Cake\Log\LogTrait;
  * Custom exception renderer class.
  * Handle with templates 500 and 400 (for status code < 500).
  */
-class ExceptionRenderer extends CakeExceptionRenderer
+class ExceptionRenderer extends WebExceptionRenderer
 {
     use LogTrait;
 
@@ -39,6 +40,19 @@ class ExceptionRenderer extends CakeExceptionRenderer
         }
 
         return $this->template = $template;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function _getController(): Controller
+    {
+        $controller = parent::_getController();
+        if ($this->request->getHeaderLine('Accept') === 'application/json') {
+            $controller->viewBuilder()->setClassName('Json');
+        }
+
+        return $controller;
     }
 
     /**

--- a/src/Error/ExceptionRenderer.php
+++ b/src/Error/ExceptionRenderer.php
@@ -48,7 +48,7 @@ class ExceptionRenderer extends WebExceptionRenderer
     protected function _getController(): Controller
     {
         $controller = parent::_getController();
-        if ($this->request->getHeaderLine('Accept') === 'application/json') {
+        if ($this->request && $this->request->getHeaderLine('Accept') === 'application/json') {
             $controller->viewBuilder()->setClassName('Json');
         }
 

--- a/src/Error/ExceptionRenderer.php
+++ b/src/Error/ExceptionRenderer.php
@@ -48,7 +48,7 @@ class ExceptionRenderer extends WebExceptionRenderer
     protected function _getController(): Controller
     {
         $controller = parent::_getController();
-        if ($this->request && $this->request->getHeaderLine('Accept') === 'application/json') {
+        if ($this->request && $this->request->is('json')) {
             $controller->viewBuilder()->setClassName('Json');
         }
 


### PR DESCRIPTION
This PR forces a JSON reponse in `ExceptionRenderer` when `application/json` Accept header is set.

Also: `Cake\Error\Renderer\WebExceptionRenderer` is used instead of the deprecated `Cake\Error\ExceptionRenderer`
