### PR TITLE
Add deprecations check

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "bedita/php-sdk": "^2.1.0",
-        "cakephp/cakephp": "^4.4.0",
+        "cakephp/cakephp": "^4.2.2",
         "cakephp/twig-view": "^1.3.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "bedita/php-sdk": "^2.1.0",
-        "cakephp/cakephp": "^4.2.2",
+        "cakephp/cakephp": "^4.4.0",
         "cakephp/twig-view": "^1.3.0"
     },
     "require-dev": {
@@ -31,8 +31,10 @@
         "cakephp/cakephp-codesniffer": "~4.5.1",
         "league/oauth2-client": "^2.6",
         "josegonzalez/dotenv": "^3.2",
-        "phpstan/phpstan": "^1.7",
-        "phpunit/phpunit": "^9.0"
+        "phpstan/phpstan": "^1.8",
+        "phpstan/extension-installer": "^1.0",
+        "phpstan/phpstan-deprecation-rules": "^1.0",
+        "phpunit/phpunit": "^9.5"
     },
     "suggest": {
         "cakephp/authentication": "^2.9 To use \"ApiIdentifier\", \"Identity\", \"IdentityHelper\" and other authentication features",
@@ -63,7 +65,8 @@
     "prefer-stable": true,
     "config": {
         "allow-plugins": {
-            "dealerdirect/phpcodesniffer-composer-installer": true
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "phpstan/extension-installer": true
         }
     }
 }

--- a/src/Command/CacheClearallCommand.php
+++ b/src/Command/CacheClearallCommand.php
@@ -32,7 +32,7 @@ class CacheClearallCommand extends BaseCommand
     public function execute(Arguments $args, ConsoleIo $io): ?int
     {
         $twigCachePath = CACHE . 'twig_view';
-        $folder = new Folder($twigCachePath);
+        $folder = new Folder($twigCachePath); /* @phpstan-ignore-line */
         if (file_exists($twigCachePath) && !$folder->delete()) {
             $io->error("Error removing Twig cache files in {$twigCachePath}");
             $this->abort();

--- a/tests/TestCase/View/Helper/AssetHelperTest.php
+++ b/tests/TestCase/View/Helper/AssetHelperTest.php
@@ -37,7 +37,7 @@ class AssetHelperTest extends TestCase
     {
         AssetsRevisions::setStrategy(new RevManifestStrategy());
         $Asset = new AssetHelper(new View());
-        $result = $Asset->get('script.js');
+        $result = $Asset->get('script.js'); /* @phpstan-ignore-line */
         static::assertEquals('script-622a2cc4f5.js', $result);
     }
 }

--- a/tests/TestCase/View/Helper/ThumbHelperTest.php
+++ b/tests/TestCase/View/Helper/ThumbHelperTest.php
@@ -240,7 +240,7 @@ class ThumbHelperTest extends TestCase
         // case response empty, with mock
         $apiMockClient = $this->getMockBuilder(BEditaClient::class)
             ->setConstructorArgs([Configure::read('API.apiBaseUrl'), Configure::read('API.apiKey')])
-            ->setMethods(['thumbs'])
+            ->onlyMethods(['thumbs'])
             ->getMock();
         $response = null;
         $apiMockClient->method('thumbs')->willReturn($response);
@@ -263,7 +263,7 @@ class ThumbHelperTest extends TestCase
         // case thumb image is acceptable
         $apiMockClient = $this->getMockBuilder(BEditaClient::class)
             ->setConstructorArgs([Configure::read('API.apiBaseUrl'), Configure::read('API.apiKey')])
-            ->setMethods(['thumbs'])
+            ->onlyMethods(['thumbs'])
             ->getMock();
         $response = [
             'meta' => [
@@ -285,7 +285,7 @@ class ThumbHelperTest extends TestCase
         // case thumb image is not acceptable
         $apiMockClient = $this->getMockBuilder(BEditaClient::class)
             ->setConstructorArgs([Configure::read('API.apiBaseUrl'), Configure::read('API.apiKey')])
-            ->setMethods(['thumbs'])
+            ->onlyMethods(['thumbs'])
         ->getMock();
         $url = 'http://...';
         $response = [
@@ -319,7 +319,7 @@ class ThumbHelperTest extends TestCase
         // case thumb ready
         $apiMockClient = $this->getMockBuilder(BEditaClient::class)
             ->setConstructorArgs([Configure::read('API.apiBaseUrl'), Configure::read('API.apiKey')])
-            ->setMethods(['thumbs'])
+            ->onlyMethods(['thumbs'])
         ->getMock();
         $response = [
             'meta' => [
@@ -340,7 +340,7 @@ class ThumbHelperTest extends TestCase
         // case thumb not ready
         $apiMockClient = $this->getMockBuilder(BEditaClient::class)
             ->setConstructorArgs([Configure::read('API.apiBaseUrl'), Configure::read('API.apiKey')])
-            ->setMethods(['thumbs'])
+            ->onlyMethods(['thumbs'])
         ->getMock();
         $url = 'http://...';
         $response = [
@@ -373,7 +373,7 @@ class ThumbHelperTest extends TestCase
         // case url not available
         $apiMockClient = $this->getMockBuilder(BEditaClient::class)
             ->setConstructorArgs([Configure::read('API.apiBaseUrl'), Configure::read('API.apiKey')])
-            ->setMethods(['thumbs'])
+            ->onlyMethods(['thumbs'])
         ->getMock();
         $response = [
             'meta' => [
@@ -394,7 +394,7 @@ class ThumbHelperTest extends TestCase
         // case url available
         $apiMockClient = $this->getMockBuilder(BEditaClient::class)
             ->setConstructorArgs([Configure::read('API.apiBaseUrl'), Configure::read('API.apiKey')])
-            ->setMethods(['thumbs'])
+            ->onlyMethods(['thumbs'])
             ->getMock();
         $url = 'http://...';
         $response = [


### PR DESCRIPTION
This PR adds automated deprecations checks via `PHPstan`  using `phpstan/phpstan-deprecation-rules` 

At the same time:
* `@phpstan-ignore-line` was added in two cases 
* phpunit deprecated `setMethods` has been replaced with `onlyMethods` 