### PR TITLE
Replace objects fields with that translated

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -33,4 +33,4 @@ jobs:
     uses: bedita/github-workflows/.github/workflows/php-unit.yml@v1
     with:
       php_versions: '["7.4","8.0","8.1"]'
-      bedita_version: '5.0.2'
+      bedita_version: '5.0.10'

--- a/src/Controller/Component/ApiFormatterComponent.php
+++ b/src/Controller/Component/ApiFormatterComponent.php
@@ -125,7 +125,10 @@ class ApiFormatterComponent extends Component
         $data = (array)Hash::get($response, 'data');
 
         if (!Hash::numeric(array_keys($data))) {
-            $response['data']['attributes'] = array_merge($response['data']['attributes'], $this->extractTranslatedFields($data, $lang));
+            $response['data']['attributes'] = array_merge(
+                $response['data']['attributes'],
+                $this->extractTranslatedFields($data, $lang)
+            );
 
             return $response;
         }

--- a/src/Controller/Component/ApiFormatterComponent.php
+++ b/src/Controller/Component/ApiFormatterComponent.php
@@ -107,4 +107,50 @@ class ApiFormatterComponent extends Component
 
         return $relationshipData;
     }
+
+    /**
+     * Replace a translation in main objects.
+     * It must be used after `included` data have been embedded using `self::embedIncluded()`.
+     *
+     * @param array $response The response API array
+     * @param string $lang The lang to search in translations
+     * @return array
+     */
+    public function replaceWithTranslation(array $response, string $lang): array
+    {
+        if (empty($response['data'])) {
+            return $response;
+        }
+
+        $data = (array)Hash::get($response, 'data');
+
+        if (!Hash::numeric(array_keys($data))) {
+            $response['data']['attributes'] = array_merge($response['data']['attributes'], $this->extractTranslatedFields($data, $lang));
+
+            return $response;
+        }
+
+        foreach ($response['data'] as &$d) {
+            $d['attributes'] = array_merge($d['attributes'], $this->extractTranslatedFields($d, $lang));
+        }
+
+        return $response;
+    }
+
+    /**
+     * Extract translated fields for a language.
+     *
+     * @param array $data The object data
+     * @param string $lang The lang to extract
+     * @return array
+     */
+    protected function extractTranslatedFields(array $data, string $lang): array
+    {
+        $path = sprintf('relationships.translations.data.{n}.attributes[lang=%s].translated_fields', $lang);
+        if ($lang === Hash::get($data, 'attributes.lang')) {
+            return [];
+        }
+
+        return array_filter(current(Hash::extract($data, $path)));
+    }
 }

--- a/tests/.env.default
+++ b/tests/.env.default
@@ -16,7 +16,7 @@ export BEDITA_ADMIN_PWD="admin"
 ## Tests using docker
 #
 # 1. pull official BEdita docker image
-# docker pull bedita/bedita:4.2.1
+# docker pull bedita/bedita:5.0.10
 #
 # 2. set test env vars like
 # export BEDITA_ADMIN_USR="admin"
@@ -25,7 +25,7 @@ export BEDITA_ADMIN_PWD="admin"
 # export BEDITA_API_KEY="1234567890"
 #
 # 3. run docker using same options with a command like:
-# docker run -p 8090:80 --env BEDITA_ADMIN_USR=admin --env BEDITA_ADMIN_PWD=admin --env BEDITA_API_KEY=1234567890 bedita/bedita:4.2.1
+# docker run -p 8090:80 --env BEDITA_ADMIN_USR=admin --env BEDITA_ADMIN_PWD=admin --env BEDITA_API_KEY=1234567890 bedita/bedita:5.0.10
 #
 # 4. run tests
 # vendor/bin/phpunit

--- a/tests/TestCase/Controller/Component/ApiFormatterComponentTest.php
+++ b/tests/TestCase/Controller/Component/ApiFormatterComponentTest.php
@@ -357,7 +357,7 @@ class ApiFormatterComponentTest extends TestCase
                 ],
                 'it',
             ],
-            'multiple objects with translation' => [
+            'multiple objects and request the object main lang' => [
                 [
                     'data' => [
                         [

--- a/tests/TestCase/Controller/Component/ApiFormatterComponentTest.php
+++ b/tests/TestCase/Controller/Component/ApiFormatterComponentTest.php
@@ -222,4 +222,404 @@ class ApiFormatterComponentTest extends TestCase
         $actual = $this->ApiFormatter->embedIncluded($response);
         static::assertEquals($expected, $actual);
     }
+
+    /**
+     * Data provider for `testReplaceWithTranslation()`.
+     *
+     * @return array
+     */
+    public function replaceWithTranslationProvider(): array
+    {
+        return [
+            'single object with translation' => [
+                [
+                    'data' => [
+                        'id' => 1,
+                        'type' => 'documents',
+                        'attributes' => [
+                            'lang' => 'it',
+                            'title' => 'Ciao',
+                            'description' => 'Mondo',
+                        ],
+                        'relationships' => [
+                            'translations' => [
+                                'links' => [],
+                                'data' => [
+                                    [
+                                        'id' => 10,
+                                        'type' => 'translations',
+                                        'attributes' => [
+                                            'lang' => 'en',
+                                            'object_id' => 1,
+                                            'translated_fields' => [
+                                                'title' => 'Hello',
+                                                'description' => 'World',
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+                [
+                    'data' => [
+                        'id' => 1,
+                        'type' => 'documents',
+                        'attributes' => [
+                            'lang' => 'it',
+                            'title' => 'Hello',
+                            'description' => 'World',
+                        ],
+                        'relationships' => [
+                            'translations' => [
+                                'links' => [],
+                                'data' => [
+                                    [
+                                        'id' => 10,
+                                        'type' => 'translations',
+                                        'attributes' => [
+                                            'lang' => 'en',
+                                            'object_id' => 1,
+                                            'translated_fields' => [
+                                                'title' => 'Hello',
+                                                'description' => 'World',
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+                'en',
+            ],
+            'single object and request the object main lang' => [
+                [
+                    'data' => [
+                        'id' => 1,
+                        'type' => 'documents',
+                        'attributes' => [
+                            'lang' => 'it',
+                            'title' => 'Ciao',
+                            'description' => 'Mondo',
+                        ],
+                        'relationships' => [
+                            'translations' => [
+                                'links' => [],
+                                'data' => [
+                                    [
+                                        'id' => 10,
+                                        'type' => 'translations',
+                                        'attributes' => [
+                                            'lang' => 'en',
+                                            'object_id' => 1,
+                                            'translated_fields' => [
+                                                'title' => 'Hello',
+                                                'description' => 'World',
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+                [
+                    'data' => [
+                        'id' => 1,
+                        'type' => 'documents',
+                        'attributes' => [
+                            'lang' => 'it',
+                            'title' => 'Ciao',
+                            'description' => 'Mondo',
+                        ],
+                        'relationships' => [
+                            'translations' => [
+                                'links' => [],
+                                'data' => [
+                                    [
+                                        'id' => 10,
+                                        'type' => 'translations',
+                                        'attributes' => [
+                                            'lang' => 'en',
+                                            'object_id' => 1,
+                                            'translated_fields' => [
+                                                'title' => 'Hello',
+                                                'description' => 'World',
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+                'it',
+            ],
+            'multiple objects with translation' => [
+                [
+                    'data' => [
+                        [
+                            'id' => 1,
+                            'type' => 'documents',
+                            'attributes' => [
+                                'lang' => 'it',
+                                'title' => 'Ciao',
+                                'description' => 'Mondo',
+                            ],
+                            'relationships' => [
+                                'translations' => [
+                                    'links' => [],
+                                    'data' => [
+                                        [
+                                            'id' => 10,
+                                            'type' => 'translations',
+                                            'attributes' => [
+                                                'lang' => 'en',
+                                                'object_id' => 1,
+                                                'translated_fields' => [
+                                                    'title' => 'Hello',
+                                                    'description' => 'World',
+                                                ],
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                        [
+                            'id' => 1,
+                            'type' => 'documents',
+                            'attributes' => [
+                                'lang' => 'it',
+                                'title' => 'Questo è il titolo',
+                                'description' => 'La descrizione',
+                            ],
+                            'relationships' => [
+                                'translations' => [
+                                    'links' => [],
+                                    'data' => [
+                                        [
+                                            'id' => 10,
+                                            'type' => 'translations',
+                                            'attributes' => [
+                                                'lang' => 'en',
+                                                'object_id' => 1,
+                                                'translated_fields' => [
+                                                    'title' => 'This is the title',
+                                                    'description' => '',
+                                                ],
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+                [
+                    'data' => [
+                        [
+                            'id' => 1,
+                            'type' => 'documents',
+                            'attributes' => [
+                                'lang' => 'it',
+                                'title' => 'Hello',
+                                'description' => 'World',
+                            ],
+                            'relationships' => [
+                                'translations' => [
+                                    'links' => [],
+                                    'data' => [
+                                        [
+                                            'id' => 10,
+                                            'type' => 'translations',
+                                            'attributes' => [
+                                                'lang' => 'en',
+                                                'object_id' => 1,
+                                                'translated_fields' => [
+                                                    'title' => 'Hello',
+                                                    'description' => 'World',
+                                                ],
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                        [
+                            'id' => 1,
+                            'type' => 'documents',
+                            'attributes' => [
+                                'lang' => 'it',
+                                'title' => 'This is the title',
+                                'description' => 'La descrizione',
+                            ],
+                            'relationships' => [
+                                'translations' => [
+                                    'links' => [],
+                                    'data' => [
+                                        [
+                                            'id' => 10,
+                                            'type' => 'translations',
+                                            'attributes' => [
+                                                'lang' => 'en',
+                                                'object_id' => 1,
+                                                'translated_fields' => [
+                                                    'title' => 'This is the title',
+                                                    'description' => '',
+                                                ],
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+                'en',
+            ],
+            'multiple objects with translation' => [
+                [
+                    'data' => [
+                        [
+                            'id' => 1,
+                            'type' => 'documents',
+                            'attributes' => [
+                                'lang' => 'it',
+                                'title' => 'Ciao',
+                                'description' => 'Mondo',
+                            ],
+                            'relationships' => [
+                                'translations' => [
+                                    'links' => [],
+                                    'data' => [
+                                        [
+                                            'id' => 10,
+                                            'type' => 'translations',
+                                            'attributes' => [
+                                                'lang' => 'en',
+                                                'object_id' => 1,
+                                                'translated_fields' => [
+                                                    'title' => 'Hello',
+                                                    'description' => 'World',
+                                                ],
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                        [
+                            'id' => 1,
+                            'type' => 'documents',
+                            'attributes' => [
+                                'lang' => 'it',
+                                'title' => 'Questo è il titolo',
+                                'description' => 'La descrizione',
+                            ],
+                            'relationships' => [
+                                'translations' => [
+                                    'links' => [],
+                                    'data' => [
+                                        [
+                                            'id' => 10,
+                                            'type' => 'translations',
+                                            'attributes' => [
+                                                'lang' => 'en',
+                                                'object_id' => 1,
+                                                'translated_fields' => [
+                                                    'title' => 'This is the title',
+                                                    'description' => '',
+                                                ],
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+                [
+                    'data' => [
+                        [
+                            'id' => 1,
+                            'type' => 'documents',
+                            'attributes' => [
+                                'lang' => 'it',
+                                'title' => 'Ciao',
+                                'description' => 'Mondo',
+                            ],
+                            'relationships' => [
+                                'translations' => [
+                                    'links' => [],
+                                    'data' => [
+                                        [
+                                            'id' => 10,
+                                            'type' => 'translations',
+                                            'attributes' => [
+                                                'lang' => 'en',
+                                                'object_id' => 1,
+                                                'translated_fields' => [
+                                                    'title' => 'Hello',
+                                                    'description' => 'World',
+                                                ],
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                        [
+                            'id' => 1,
+                            'type' => 'documents',
+                            'attributes' => [
+                                'lang' => 'it',
+                                'title' => 'Questo è il titolo',
+                                'description' => 'La descrizione',
+                            ],
+                            'relationships' => [
+                                'translations' => [
+                                    'links' => [],
+                                    'data' => [
+                                        [
+                                            'id' => 10,
+                                            'type' => 'translations',
+                                            'attributes' => [
+                                                'lang' => 'en',
+                                                'object_id' => 1,
+                                                'translated_fields' => [
+                                                    'title' => 'This is the title',
+                                                    'description' => '',
+                                                ],
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+                'it',
+            ],
+        ];
+    }
+
+    /**
+     * Test `replaceWithTranslation()` method.
+     *
+     * @param array $response The response data
+     * @param array $expected The expected data
+     * @param string $lang The lang requested
+     * @return void
+     * @covers ::testReplaceWithTranslation()
+     * @covers ::extractTranslatedFields()
+     * @dataProvider replaceWithTranslationProvider()
+     */
+    public function testReplaceWithTranslation(array $response, array $expected, string $lang): void
+    {
+        $actual = $this->ApiFormatter->replaceWithTranslation($response, $lang);
+        static::assertEquals($expected, $actual);
+    }
 }


### PR DESCRIPTION
This PR add a method to `ApiFormatterComponent` to replace fields of objects with a translation.