### PR TITLE
Use same `roles` format in `Identifier` response

### DIFF
--- a/src/Identifier/ApiIdentifier.php
+++ b/src/Identifier/ApiIdentifier.php
@@ -76,9 +76,8 @@ class ApiIdentifier extends AbstractIdentifier
         }
 
         $roles = Hash::extract($result, 'included.{n}.attributes.name');
-        $identity = $result['data'] + compact('tokens') + compact('roles');
 
-        return $identity;
+        return $result['data'] + compact('tokens') + compact('roles');
     }
 
     /**

--- a/src/Identifier/OAuth2Identifier.php
+++ b/src/Identifier/OAuth2Identifier.php
@@ -92,9 +92,9 @@ class OAuth2Identifier extends AbstractIdentifier
      * Perform OAuth2 signup and login after signup.
      *
      * @param array $credentials Identifier credentials
-     * @return \ArrayObject|null;
+     * @return array|null;
      */
-    protected function signup(array $credentials): ?ArrayObject
+    protected function signup(array $credentials): ?array
     {
         $data = $this->signupData($credentials);
         try {

--- a/src/Identifier/OAuth2Identifier.php
+++ b/src/Identifier/OAuth2Identifier.php
@@ -74,18 +74,18 @@ class OAuth2Identifier extends AbstractIdentifier
      * Perform external login via `/auth`.
      *
      * @param array $credentials Identifier credentials
-     * @return \ArrayObject
+     * @return array
      */
-    protected function externalAuth(array $credentials): ArrayObject
+    protected function externalAuth(array $credentials): array
     {
         $apiClient = ApiClientProvider::getApiClient();
         $result = $apiClient->post('/auth', json_encode($credentials), ['Content-Type' => 'application/json']);
         $tokens = $result['meta'];
         $result = $apiClient->get('/auth/user', null, ['Authorization' => sprintf('Bearer %s', $tokens['jwt'])]);
 
-        return new ArrayObject($result['data']
-            + compact('tokens')
-            + Hash::combine($result, 'included.{n}.attributes.name', 'included.{n}.id', 'included.{n}.type'));
+        $roles = Hash::extract($result, 'included.{n}.attributes.name');
+
+        return $result['data'] + compact('tokens') + compact('roles');
     }
 
     /**

--- a/src/Identifier/OAuth2Identifier.php
+++ b/src/Identifier/OAuth2Identifier.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
  */
 namespace BEdita\WebTools\Identifier;
 
-use ArrayObject;
 use Authentication\Identifier\AbstractIdentifier;
 use BEdita\SDK\BEditaClientException;
 use BEdita\WebTools\ApiClientProvider;

--- a/tests/TestCase/Identifier/OAuth2IdentifierTest.php
+++ b/tests/TestCase/Identifier/OAuth2IdentifierTest.php
@@ -56,18 +56,24 @@ class OAuth2IdentifierTest extends TestCase
         ]);
         $apiClientMock->method('get')->willReturn([
             'data' => ['id' => 1],
+            'included' => [
+                [
+                    'attributes' => ['name' => 'support'],
+                ],
+            ],
         ]);
 
         $identifier = new OAuth2Identifier();
         ApiClientProvider::setApiClient($apiClientMock);
 
         $identity = $identifier->identify([]);
-        $expected = new ArrayObject([
+        $expected = [
             'id' => 1,
             'tokens' => [
                 'jwt' => 'gustavo',
             ],
-        ]);
+            'roles' => ['support'],
+        ];
         static::assertEquals($expected, $identity);
     }
 

--- a/tests/TestCase/Identifier/OAuth2IdentifierTest.php
+++ b/tests/TestCase/Identifier/OAuth2IdentifierTest.php
@@ -15,7 +15,6 @@ declare(strict_types=1);
 
 namespace BEdita\WebTools\Test\TestCase\Identifier;
 
-use ArrayObject;
 use BEdita\SDK\BEditaClient;
 use BEdita\SDK\BEditaClientException;
 use BEdita\WebTools\ApiClientProvider;
@@ -141,12 +140,13 @@ class OAuth2IdentifierTest extends TestCase
         ApiClientProvider::setApiClient($apiClientMock);
 
         $identity = $identifier->identify(['auth_provider' => 'gustavo']);
-        $expected = new ArrayObject([
+        $expected = [
             'id' => 1,
             'tokens' => [
                 'jwt' => 'gustavo',
             ],
-        ]);
+            'roles' => [],
+        ];
         static::assertEquals($expected, $identity);
     }
 


### PR DESCRIPTION
This PR fixes an inconsistency between `ApiIdentifier` and `OAuth2Identifier` identity array format.
