### PR TITLE
Manual release with Release workflow 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,17 @@ name: Release
 on:
   pull_request_target:
     types: [closed]
+  workflow_dispatch:
+    inputs:
+      releaseType:
+        description: 'Release type'
+        required: true
+        default: 'patch'
+        type: choice
+        options:
+        - patch
+        - minor
+        - major
 
 jobs:
   release-job:
@@ -10,3 +21,4 @@ jobs:
     with:
       main_branch: 'master'
       dist_branches: '["master","1.x"]'
+      version_bump: ${{ inputs.releaseType }}


### PR DESCRIPTION
This provides the possibility to create a release using the reusable workflow Release (this is possible after https://github.com/bedita/github-workflows/pull/16).

Usual PR labels still work as expected (on merging PR with release:* labels, Release workflow create the release, the tag, etc.).