### PR TITLE
Upgrade cakephp 4.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "bedita/php-sdk": "^2.1.0",
-        "cakephp/cakephp": "^4.2.2",
+        "cakephp/cakephp": "^4.5.0",
         "cakephp/twig-view": "^1.3.0"
     },
     "require-dev": {


### PR DESCRIPTION
This updates composer dependency for cakephp to version 4.5

Note: `cd <cakephp-upgrade-path>; bin/cake upgrade rector --rules cakephp45 <webtools-path>/src`, no change applied.

