### PR TITLE
Handle Apple Sign-In via OAuth2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
         "php": "^7.4 || ^8.0",
         "bedita/php-sdk": "^2.1.0",
         "cakephp/cakephp": "^4.2.2",
+        "firebase/php-jwt": "^6.9",
         "cakephp/twig-view": "^1.3.0"
     },
     "require-dev": {

--- a/src/Authenticator/OAuth2Authenticator.php
+++ b/src/Authenticator/OAuth2Authenticator.php
@@ -22,6 +22,7 @@ use Cake\Http\Exception\BadRequestException;
 use Cake\Log\LogTrait;
 use Cake\Routing\Router;
 use Cake\Utility\Hash;
+use Firebase\JWT\JWT;
 use Psr\Http\Message\ServerRequestInterface;
 
 /**
@@ -85,6 +86,12 @@ class OAuth2Authenticator extends AbstractAuthenticator
     {
         // extract provider from request
         $provider = basename($request->getUri()->getPath());
+        $this->log('[OAuth2Authenticator] provider: ' . $provider, 'info');
+        // leeway is needed for clock skew
+        $leeway = (int)$this->getConfig(sprintf('providers.%s.clientOptions.jwtLeeway', $provider), 0);
+        if ($leeway) {
+            JWT::$leeway = $leeway;
+        }
 
         $connect = $this->providerConnect($provider, $request);
         if (!empty($connect[static::AUTH_URL_KEY])) {
@@ -97,7 +104,9 @@ class OAuth2Authenticator extends AbstractAuthenticator
             'provider_username' => Hash::get($connect, sprintf('user.%s', $usernameField)),
             'access_token' => Hash::get($connect, 'token.access_token'),
             'provider_userdata' => (array)Hash::get($connect, 'user'),
+            'id_token' => Hash::get($connect, 'token.id_token'),
         ];
+        $this->log('[OAuth2Authenticator] identify user with: ' . json_encode($data), 'info');
         $user = $this->_identifier->identify($data);
 
         if (empty($user)) {
@@ -119,7 +128,12 @@ class OAuth2Authenticator extends AbstractAuthenticator
     {
         $this->initProvider($provider, $request);
 
-        $query = $request->getQueryParams();
+        if ($request->getMethod() === 'GET') {
+            $query = $request->getQueryParams();
+        } else {
+            $query = $request->getParsedBody();
+        }
+        $this->log('[OAuth2Authenticator] Provider connect query: ' . json_encode($query), 'info');
         $sessionKey = $this->getConfig('sessionKey');
         /** @var \Cake\Http\Session $session */
         $session = $request->getAttribute('session');
@@ -127,14 +141,22 @@ class OAuth2Authenticator extends AbstractAuthenticator
         if (!isset($query['code'])) {
             // If we don't have an authorization code then get one
             $options = (array)$this->getConfig(sprintf('providers.%s.options', $provider));
+            $this->log('[OAuth2Authenticator] Provider options: ' . json_encode($options), 'info');
             $authUrl = $this->provider->getAuthorizationUrl($options);
+            $this->log('[OAuth2Authenticator] State: ' . $this->provider->getState(), 'info');
+            $this->log('[OAuth2Authenticator] Session id: ' . $session->id(), 'info');
             $session->write($sessionKey, $this->provider->getState());
+            $this->log('[OAuth2Authenticator] Authorization URL: ' . $authUrl, 'info');
 
             return [static::AUTH_URL_KEY => $authUrl];
         }
 
         // Check given state against previously stored one to mitigate CSRF attack
-        if (empty($query['state']) || ($query['state'] !== $session->read($sessionKey))) {
+        $this->log('[OAuth2Authenticator] Session id: ' . $session->id(), 'info');
+        if (
+            (empty($query['state']) || $query['state'] !== $session->read($sessionKey))
+            && $request->getMethod() === 'GET'
+        ) {
             $session->delete($sessionKey);
             throw new BadRequestException('Invalid state');
         }
@@ -142,8 +164,10 @@ class OAuth2Authenticator extends AbstractAuthenticator
         // Try to get an access token (using the authorization code grant)
         /** @var \League\OAuth2\Client\Token\AccessToken $token */
         $token = $this->provider->getAccessToken('authorization_code', ['code' => $query['code']]);
+        $this->log('[OAuth2Authenticator] Access token via auth code: ' . json_encode($token->jsonSerialize()), 'info');
         // We got an access token, let's now get the user's details
         $user = $this->provider->getResourceOwner($token)->toArray();
+        $this->log('[OAuth2Authenticator] User: ' . json_encode($user), 'info');
         $token = $token->jsonSerialize();
 
         return compact('token', 'user');

--- a/src/Identifier/OAuth2Identifier.php
+++ b/src/Identifier/OAuth2Identifier.php
@@ -77,6 +77,7 @@ class OAuth2Identifier extends AbstractIdentifier
      */
     protected function externalAuth(array $credentials): array
     {
+        $this->log('[OAuth2Identifier] Signing in with credentials: ' . json_encode($credentials), 'info');
         $apiClient = ApiClientProvider::getApiClient();
         $result = $apiClient->post('/auth', json_encode($credentials), ['Content-Type' => 'application/json']);
         $tokens = $result['meta'];
@@ -95,10 +96,12 @@ class OAuth2Identifier extends AbstractIdentifier
      */
     protected function signup(array $credentials): ?array
     {
+        $this->log('[OAuth2Identifier] Signin up with credentials: ' . json_encode($credentials), 'info');
         $data = $this->signupData($credentials);
         try {
             $apiClient = ApiClientProvider::getApiClient();
             $apiClient->setupTokens([]);
+            $this->log('[OAuth2Identifier] BEdita Signup data: ' . json_encode($data), 'info');
             $apiClient->post('/signup', json_encode($data), ['Content-Type' => 'application/json']);
             // login after signup
             $user = $this->externalAuth($credentials);

--- a/src/Identifier/OAuth2Identifier.php
+++ b/src/Identifier/OAuth2Identifier.php
@@ -77,7 +77,6 @@ class OAuth2Identifier extends AbstractIdentifier
      */
     protected function externalAuth(array $credentials): array
     {
-        $this->log('[OAuth2Identifier] Signing in with credentials: ' . json_encode($credentials), 'info');
         $apiClient = ApiClientProvider::getApiClient();
         $result = $apiClient->post('/auth', json_encode($credentials), ['Content-Type' => 'application/json']);
         $tokens = $result['meta'];
@@ -96,12 +95,10 @@ class OAuth2Identifier extends AbstractIdentifier
      */
     protected function signup(array $credentials): ?array
     {
-        $this->log('[OAuth2Identifier] Signin up with credentials: ' . json_encode($credentials), 'info');
         $data = $this->signupData($credentials);
         try {
             $apiClient = ApiClientProvider::getApiClient();
             $apiClient->setupTokens([]);
-            $this->log('[OAuth2Identifier] BEdita Signup data: ' . json_encode($data), 'info');
             $apiClient->post('/signup', json_encode($data), ['Content-Type' => 'application/json']);
             // login after signup
             $user = $this->externalAuth($credentials);

--- a/tests/TestCase/View/Helper/HtmlHelperTest.php
+++ b/tests/TestCase/View/Helper/HtmlHelperTest.php
@@ -143,11 +143,11 @@ class HtmlHelperTest extends TestCase
             ],
             'dummy description' => [
                 'dummy',
-                '<meta name="description" content="dummy"/>',
+                '<meta name="description" content="dummy">',
             ],
             'description with special chars and tags' => [
                 'dummy <> & dummy',
-                '<meta name="description" content="dummy  &amp;amp; dummy"/>',
+                '<meta name="description" content="dummy  &amp;amp; dummy">',
             ],
         ];
     }
@@ -185,11 +185,11 @@ class HtmlHelperTest extends TestCase
             ],
             'dummy creator' => [
                 'dummy',
-                '<meta name="author" content="dummy"/>',
+                '<meta name="author" content="dummy">',
             ],
             'creator with special chars and tags' => [
                 'dummy <> & dummy',
-                '<meta name="author" content="dummy &amp;lt;&amp;gt; &amp;amp; dummy"/>',
+                '<meta name="author" content="dummy &amp;lt;&amp;gt; &amp;amp; dummy">',
             ],
         ];
     }
@@ -219,7 +219,7 @@ class HtmlHelperTest extends TestCase
         return [
             'empty docType' => [
                 '',
-                '<meta http-equiv="Content-Style-Type" content="text/css"/>',
+                '<meta http-equiv="Content-Style-Type" content="text/css">',
             ],
             'html5 docType' => [
                 'html5',
@@ -266,14 +266,14 @@ class HtmlHelperTest extends TestCase
                 [
                     'name' => 'Dummy',
                 ],
-                '<meta name="generator" content="Dummy"/>',
+                '<meta name="generator" content="Dummy">',
             ],
             'project and version' => [
                 [
                     'name' => 'Dummy',
                     'version' => '1.0',
                 ],
-                '<meta name="generator" content="Dummy 1.0"/>',
+                '<meta name="generator" content="Dummy 1.0">',
             ],
         ];
     }
@@ -303,7 +303,7 @@ class HtmlHelperTest extends TestCase
         return [
             'empty data' => [
                 [],
-                '<meta http-equiv="Content-Style-Type" content="text/css"/>',
+                '<meta http-equiv="Content-Style-Type" content="text/css">',
             ],
             'full data' => [
                 [
@@ -317,7 +317,7 @@ class HtmlHelperTest extends TestCase
                         'version' => '2.0',
                     ],
                 ],
-                '<meta name="description" content="dummy description"/><meta name="author" content="gustavo"/><meta http-equiv="Content-Style-Type" content="text/css"/><meta name="generator" content="my dummy project 2.0"/><meta name="viewport" content="width=device-width, initial-scale=1.0"/><meta name="msapplication-TileColor" content="#009cc7"/><meta name="theme-color" content="#ABC000"/>',
+                '<meta name="description" content="dummy description"><meta name="author" content="gustavo"><meta http-equiv="Content-Style-Type" content="text/css"><meta name="generator" content="my dummy project 2.0"><meta name="viewport" content="width=device-width, initial-scale=1.0"><meta name="msapplication-TileColor" content="#009cc7"><meta name="theme-color" content="#ABC000">',
             ],
         ];
     }
@@ -356,7 +356,7 @@ class HtmlHelperTest extends TestCase
                     'description' => 'a dummy data for test',
                     'image' => 'an image',
                 ],
-                '<meta property="og:url" content="https://example.com"/><meta property="og:title" content="dummy"/><meta property="og:description" content="a dummy data for test"/><meta property="og:image" content="an image"/>',
+                '<meta property="og:url" content="https://example.com"><meta property="og:title" content="dummy"><meta property="og:description" content="a dummy data for test"><meta property="og:image" content="an image">',
             ],
         ];
     }
@@ -397,7 +397,7 @@ class HtmlHelperTest extends TestCase
                     'description' => 'a dummy data for test',
                     'image' => 'an image',
                 ],
-                '<meta property="twitter:card" content="whatever"/><meta property="twitter:site" content="example.com"/><meta property="twitter:creator" content="gustavo"/><meta property="twitter:title" content="dummy"/><meta property="twitter:description" content="a dummy data for test"/><meta property="twitter:image" content="an image"/>',
+                '<meta property="twitter:card" content="whatever"><meta property="twitter:site" content="example.com"><meta property="twitter:creator" content="gustavo"><meta property="twitter:title" content="dummy"><meta property="twitter:description" content="a dummy data for test"><meta property="twitter:image" content="an image">',
             ],
         ];
     }


### PR DESCRIPTION
This PR provides changes to `OAuth2Authenticator` class to support Apple Sign-In process, where:

* a JWT `leeway` configuration may be needed 
* return call from authorization URL is performed via POST
* `id_token` must be used for user verification