### PR TITLE
bedita github-workflows v2 and php 8.3

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      gh-actions:
+        patterns: ['actions/*']
+      docker:
+        patterns: ['docker/*']
+      codecov:
+        patterns: ['codecov/*']

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -14,23 +14,23 @@ on:
 
 jobs:
   cs:
-    uses: bedita/github-workflows/.github/workflows/php-cs.yml@v1
+    uses: bedita/github-workflows/.github/workflows/php-cs.yml@v2
     with:
-      php_versions: '["7.4","8.1","8.2"]'
+      php_versions: '["7.4","8.1","8.2","8.3"]'
 
   stan:
-    uses: bedita/github-workflows/.github/workflows/php-stan.yml@v1
+    uses: bedita/github-workflows/.github/workflows/php-stan.yml@v2
     with:
-      php_versions: '["7.4","8.1","8.2"]'
+      php_versions: '["7.4","8.1","8.2","8.3"]'
 
   unit-4:
-    uses: bedita/github-workflows/.github/workflows/php-unit.yml@v1
+    uses: bedita/github-workflows/.github/workflows/php-unit.yml@v2
     with:
-      php_versions: '["7.4","8.1","8.2"]'
+      php_versions: '["7.4","8.1","8.2","8.3"]'
       bedita_version: '4'
 
   unit-5:
-    uses: bedita/github-workflows/.github/workflows/php-unit.yml@v1
+    uses: bedita/github-workflows/.github/workflows/php-unit.yml@v2
     with:
-      php_versions: '["7.4","8.1","8.2"]'
+      php_versions: '["7.4","8.1","8.2","8.3"]'
       bedita_version: '5'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   release-job:
-    uses: bedita/github-workflows/.github/workflows/release.yml@v1
+    uses: bedita/github-workflows/.github/workflows/release.yml@v2
     with:
       main_branch: 'master'
       dist_branches: '["master","1.x"]'


### PR DESCRIPTION
This updates github workflows to use bedita github-workflows v2 and php 8.3.
Bonus: add dependabot config to open automatically PR on action/codecov/docker updates.