### PR TITLE
Prepare major release 5: BEdita 5 only, php >= 8.1, cakephp 4.5

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -23,16 +23,9 @@ jobs:
     with:
       php_versions: '["8.3"]'
 
-  unit-4:
-    uses: bedita/github-workflows/.github/workflows/php-unit.yml@v2
-    with:
-      php_versions: '["7.4","8.1","8.2","8.3"]'
-      bedita_version: '4'
-      coverage_min_percentage: 99
-
   unit-5:
     uses: bedita/github-workflows/.github/workflows/php-unit.yml@v2
     with:
-      php_versions: '["7.4","8.1","8.2","8.3"]'
+      php_versions: '["8.1","8.2","8.3"]'
       bedita_version: '5'
       coverage_min_percentage: 99

--- a/composer.json
+++ b/composer.json
@@ -20,9 +20,9 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": ">=8.1",
         "bedita/php-sdk": "^3.1.0",
-        "cakephp/cakephp": "^4.2.2",
+        "cakephp/cakephp": "^4.5",
         "firebase/php-jwt": "^6.9",
         "cakephp/twig-view": "^1.3.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -29,13 +29,13 @@
     "require-dev": {
         "cakephp/authentication": "^2.9",
         "cakephp/authorization": "^2.2",
-        "cakephp/cakephp-codesniffer": "~4.5.1",
+        "cakephp/cakephp-codesniffer": "^4.7",
         "league/oauth2-client": "^2.6",
         "josegonzalez/dotenv": "^3.2",
-        "phpstan/phpstan": "^1.8",
-        "phpstan/extension-installer": "^1.0",
-        "phpstan/phpstan-deprecation-rules": "^1.0",
-        "phpunit/phpunit": "^9.5"
+        "phpstan/phpstan": "^1.10",
+        "phpstan/extension-installer": "^1.2",
+        "phpstan/phpstan-deprecation-rules": "^1.2",
+        "phpunit/phpunit": "^9.6"
     },
     "suggest": {
         "cakephp/authentication": "^2.9 To use \"ApiIdentifier\", \"Identity\", \"IdentityHelper\" and other authentication features",


### PR DESCRIPTION
This introduces some breaking changes:

 - php >= 8.1
 - bedita >= 5
 - cakephp >= 4.5