### PR TITLE
Bump php-sdk to v4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     ],
     "require": {
         "php": ">=8.1",
-        "bedita/php-sdk": "^3.1.0",
+        "bedita/php-sdk": "^4.0.0",
         "cakephp/cakephp": "^4.5",
         "firebase/php-jwt": "^6.9",
         "cakephp/twig-view": "^1.3.0"


### PR DESCRIPTION
This updates dependencies to use `bedita/php-sdk:^4.0.0`.