### PR TITLE
Api response clean utility

### DIFF
--- a/src/Controller/Component/ApiFormatterComponent.php
+++ b/src/Controller/Component/ApiFormatterComponent.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 
 namespace BEdita\WebTools\Controller\Component;
 
+use BEdita\WebTools\Utility\ApiTools;
 use Cake\Collection\Collection;
 use Cake\Controller\Component;
 use Cake\Utility\Hash;
@@ -157,5 +158,19 @@ class ApiFormatterComponent extends Component
         $translatedFields = (array)Hash::extract($data, $path);
 
         return array_filter((array)array_shift($translatedFields));
+    }
+
+    /**
+     * Clean response from unwanted keys (recursively).
+     *
+     * @param array $response The response from API
+     * @param array $options The options to clean response
+     * @return array
+     */
+    public function cleanResponse(
+        array $response,
+        array $options = ['included', 'links', 'schema', 'relationships']
+    ): array {
+        return ApiTools::cleanResponse($response, $options);
     }
 }

--- a/src/Utility/ApiTools.php
+++ b/src/Utility/ApiTools.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2025 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+namespace BEdita\WebTools\Utility;
+
+use Cake\Utility\Hash;
+
+/**
+ * Api utility methods
+ */
+class ApiTools
+{
+    /**
+     * Remove included from response.
+     *
+     * @param array $response The response from api client
+     * @return array
+     */
+    public static function removeIncluded(array $response): array
+    {
+        return (array)Hash::remove($response, 'included');
+    }
+
+    /**
+     * Remove `links` from response (recursively).
+     *
+     * @param array $response The response from api client
+     * @return array
+     */
+    public static function removeLinks(array $response): array
+    {
+        return self::recursiveRemoveKey($response, 'links');
+    }
+
+    /**
+     * Remove `relationships` from response (recursively).
+     *
+     * @param array $response The response from api client
+     * @return array
+     */
+    public static function removeRelationships(array $response): array
+    {
+        return self::recursiveRemoveKey($response, 'relationships');
+    }
+
+    /**
+     * Remove `schema` from response.
+     *
+     * @param array $response The response from api client
+     * @return array
+     */
+    public static function removeSchema(array $response): array
+    {
+        return (array)Hash::remove($response, 'meta.schema');
+    }
+
+    /**
+     * Remove a key in an array recursively.
+     *
+     * @param array $data The starting data
+     * @param string $key The key to remove
+     * @return array
+     */
+    public static function recursiveRemoveKey(array $data, string $key): array
+    {
+        foreach ($data as $k => $v) {
+            if (is_array($v)) {
+                $data[$k] = self::recursiveRemoveKey($v, $key);
+            }
+        }
+
+        return array_filter(
+            $data,
+            function ($k) use ($key) {
+                return $k !== $key;
+            },
+            ARRAY_FILTER_USE_KEY
+        );
+    }
+
+    /**
+     * Clean response.
+     *
+     * @param array $response The response.
+     * @param array $options The options to clean.
+     * @return array
+     */
+    public static function cleanResponse(
+        array $response,
+        array $options = ['included', 'links', 'schema', 'relationships']
+    ): array {
+        foreach ($options as $option) {
+            $method = 'remove' . ucfirst($option);
+            $response = self::$method($response);
+        }
+
+        return $response;
+    }
+}

--- a/src/Utility/ApiTools.php
+++ b/src/Utility/ApiTools.php
@@ -41,6 +41,8 @@ class ApiTools
      */
     public static function removeLinks(array $response): array
     {
+        $response = (array)Hash::remove($response, 'links');
+
         return self::recursiveRemoveKey($response, 'links');
     }
 

--- a/tests/TestCase/Controller/Component/ApiFormatterComponentTest.php
+++ b/tests/TestCase/Controller/Component/ApiFormatterComponentTest.php
@@ -812,6 +812,11 @@ class ApiFormatterComponentTest extends TestCase
                     ],
                 ],
             ],
+            'links' => [
+                'self' => 'https://api.example.org/users',
+                'first' => 'https://api.example.org/users?page=1',
+                'last' => 'https://api.example.org/users?page=1',
+            ],
         ];
         $actual = $this->ApiFormatter->cleanResponse($response);
         $expected = [

--- a/tests/TestCase/Controller/Component/ApiFormatterComponentTest.php
+++ b/tests/TestCase/Controller/Component/ApiFormatterComponentTest.php
@@ -741,4 +741,101 @@ class ApiFormatterComponentTest extends TestCase
         $actual = $this->ApiFormatter->replaceWithTranslation($response, $lang);
         static::assertEquals($expected, $actual);
     }
+
+    /**
+     * Test `cleanResponse()` method.
+     *
+     * @return void
+     * @covers ::cleanResponse()
+     */
+    public function testCleanResponse(): void
+    {
+        $response = [
+            'data' => [
+                [
+                    'id' => 1,
+                    'attributes' => [
+                        'uname' => 'gustavo',
+                        'title' => 'gustavo supporto',
+                        'name' => 'gustavo',
+                        'surname' => 'supporto',
+                    ],
+                    'links' => [
+                        'self' => 'https://api.example.org/users/1',
+                    ],
+                    'relationships' => [
+                        'roles' => [
+                            'links' => [
+                                'self' => 'https://api.example.org/users/1/relationships/roles',
+                                'related' => 'https://api.example.org/users/1/roles',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            'meta' => [
+                'pagination' => [
+                    'page' => 1,
+                    'page_count' => 1,
+                    'page_items' => 1,
+                    'page_size' => 20,
+                    'count' => 1,
+                ],
+                'schema' => [
+                    'type' => 'object',
+                    'properties' => [
+                        'id' => [
+                            'type' => 'integer',
+                        ],
+                        'type' => [
+                            'type' => 'string',
+                        ],
+                        'attributes' => [
+                            'type' => 'object',
+                        ],
+                        'links' => [
+                            'type' => 'object',
+                        ],
+                        'relationships' => [
+                            'type' => 'object',
+                        ],
+                    ],
+                    'required' => ['id', 'type', 'attributes'],
+                ],
+            ],
+            'included' => [
+                [
+                    'id' => 1,
+                    'type' => 'roles',
+                    'attributes' => [
+                        'name' => 'admin',
+                    ],
+                ],
+            ],
+        ];
+        $actual = $this->ApiFormatter->cleanResponse($response);
+        $expected = [
+            'data' => [
+                [
+                    'id' => 1,
+                    'attributes' => [
+                        'uname' => 'gustavo',
+                        'title' => 'gustavo supporto',
+                        'name' => 'gustavo',
+                        'surname' => 'supporto',
+                    ],
+                ],
+            ],
+            'meta' => [
+                'pagination' => [
+                    'page' => 1,
+                    'page_count' => 1,
+                    'page_items' => 1,
+                    'page_size' => 20,
+                    'count' => 1,
+                ],
+            ],
+        ];
+        static::assertEquals($expected, $actual);
+    }
 }

--- a/tests/TestCase/Utility/ApiToolsTest.php
+++ b/tests/TestCase/Utility/ApiToolsTest.php
@@ -1,0 +1,128 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2020 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+namespace BEdita\WebTools\Test\TestCase\Utility;
+
+use BEdita\WebTools\Utility\ApiTools;
+use Cake\TestSuite\TestCase;
+
+/**
+ * {@see \BEdita\WebTools\Utility\ApiTools} Test Case
+ *
+ * @coversDefaultClass \BEdita\WebTools\Utility\ApiTools
+ */
+class ApiToolsTest extends TestCase
+{
+    /**
+     * Test clean response
+     *
+     * @return void
+     * @covers ::cleanResponse()
+     * @covers ::recursiveRemoveKey()
+     * @covers ::removeIncluded()
+     * @covers ::removeLinks()
+     * @covers ::removeRelationships()
+     * @covers ::removeSchema()
+     */
+    public function testCleanResponse(): void
+    {
+        $response = [
+            'data' => [
+                [
+                    'id' => 1,
+                    'attributes' => [
+                        'uname' => 'gustavo',
+                        'title' => 'gustavo supporto',
+                        'name' => 'gustavo',
+                        'surname' => 'supporto',
+                    ],
+                    'links' => [
+                        'self' => 'https://api.example.org/users/1',
+                    ],
+                    'relationships' => [
+                        'roles' => [
+                            'links' => [
+                                'self' => 'https://api.example.org/users/1/relationships/roles',
+                                'related' => 'https://api.example.org/users/1/roles',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            'meta' => [
+                'pagination' => [
+                    'page' => 1,
+                    'page_count' => 1,
+                    'page_items' => 1,
+                    'page_size' => 20,
+                    'count' => 1,
+                ],
+                'schema' => [
+                    'type' => 'object',
+                    'properties' => [
+                        'id' => [
+                            'type' => 'integer',
+                        ],
+                        'type' => [
+                            'type' => 'string',
+                        ],
+                        'attributes' => [
+                            'type' => 'object',
+                        ],
+                        'links' => [
+                            'type' => 'object',
+                        ],
+                        'relationships' => [
+                            'type' => 'object',
+                        ],
+                    ],
+                    'required' => ['id', 'type', 'attributes'],
+                ],
+            ],
+            'included' => [
+                [
+                    'id' => 1,
+                    'type' => 'roles',
+                    'attributes' => [
+                        'name' => 'admin',
+                    ],
+                ],
+            ],
+        ];
+        $actual = ApiTools::cleanResponse($response);
+        $expected = [
+            'data' => [
+                [
+                    'id' => 1,
+                    'attributes' => [
+                        'uname' => 'gustavo',
+                        'title' => 'gustavo supporto',
+                        'name' => 'gustavo',
+                        'surname' => 'supporto',
+                    ],
+                ],
+            ],
+            'meta' => [
+                'pagination' => [
+                    'page' => 1,
+                    'page_count' => 1,
+                    'page_items' => 1,
+                    'page_size' => 20,
+                    'count' => 1,
+                ],
+            ],
+        ];
+        static::assertEquals($expected, $actual);
+    }
+}

--- a/tests/TestCase/Utility/ApiToolsTest.php
+++ b/tests/TestCase/Utility/ApiToolsTest.php
@@ -99,6 +99,11 @@ class ApiToolsTest extends TestCase
                     ],
                 ],
             ],
+            'links' => [
+                'self' => 'https://api.example.org/users',
+                'first' => 'https://api.example.org/users?page=1',
+                'last' => 'https://api.example.org/users?page=1',
+            ],
         ];
         $actual = ApiTools::cleanResponse($response);
         $expected = [


### PR DESCRIPTION
This provides:

 - a new method `cleanResponse` in `ApiFormatterComponent`
 - a new utility class `ApiTools` that provides "clean response" methods, reusable elsewhere