### PR TITLE
Always cast `provider_username` to string

### DIFF
--- a/src/Authenticator/OAuth2Authenticator.php
+++ b/src/Authenticator/OAuth2Authenticator.php
@@ -100,7 +100,7 @@ class OAuth2Authenticator extends AbstractAuthenticator
         $usernameField = (string)$this->getConfig(sprintf('providers.%s.map.provider_username', $provider));
         $data = [
             'auth_provider' => $provider,
-            'provider_username' => Hash::get($connect, sprintf('user.%s', $usernameField)),
+            'provider_username' => (string)Hash::get($connect, sprintf('user.%s', $usernameField)),
             'access_token' => Hash::get($connect, 'token.access_token'),
             'provider_userdata' => (array)Hash::get($connect, 'user'),
             'id_token' => Hash::get($connect, 'token.id_token'),


### PR DESCRIPTION
This PR fixes an issue with provider username not being cast to string. This caused an error when provider username is e.g. a numeric ID that references the user in a third-party repository.