### PR TITLE
Fix: safely load plugin twig view

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,5 +20,5 @@ jobs:
     uses: bedita/github-workflows/.github/workflows/release.yml@v2
     with:
       main_branch: 'master'
-      dist_branches: '["master","1.x"]'
+      dist_branches: '["master","5.x"]'
       version_bump: ${{ inputs.releaseType }}

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -18,6 +18,7 @@ use BEdita\WebTools\Command\CacheClearallCommand;
 use Cake\Console\CommandCollection;
 use Cake\Core\BasePlugin;
 use Cake\Core\PluginApplicationInterface;
+use Cake\Http\BaseApplication;
 
 /**
  * Plugin class for BEdita\WebTools.
@@ -54,7 +55,11 @@ class Plugin extends BasePlugin
         // Call parent to load bootstrap from files.
         parent::bootstrap($app);
 
+        assert($app instanceof BaseApplication);
+
         // Load more plugins here
-        $app->addPlugin('Cake/TwigView');
+        if (!$app->getPlugins()->has('Cake/TwigView')) {
+            $app->addPlugin('Cake/TwigView');
+        }
     }
 }


### PR DESCRIPTION
This is to avoid a `CakeException: "Plugin named Cake\TwigView is already loaded"` on plugin bootstrap, when the app already has "Cake\TwigView".