### PR TITLE
Rename plugin class

### DIFF
--- a/src/WebToolsPlugin.php
+++ b/src/WebToolsPlugin.php
@@ -23,7 +23,7 @@ use Cake\Http\BaseApplication;
 /**
  * Plugin class for BEdita\WebTools.
  */
-class Plugin extends BasePlugin
+class WebToolsPlugin extends BasePlugin
 {
     /**
      * Load routes or not

--- a/tests/TestCase/PluginTest.php
+++ b/tests/TestCase/PluginTest.php
@@ -15,7 +15,7 @@ declare(strict_types=1);
 namespace BEdita\WebTools\Test\TestCase;
 
 use BEdita\WebTools\Command\CacheClearallCommand;
-use BEdita\WebTools\Plugin;
+use BEdita\WebTools\WebToolsPlugin;
 use Cake\Console\CommandCollection;
 use Cake\TestSuite\TestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -23,11 +23,11 @@ use PHPUnit\Framework\Attributes\CoversMethod;
 use TestApp\Application;
 
 /**
- * {@see BEdita\WebTools\Plugin} Test Case
+ * {@see BEdita\WebTools\WebToolsPlugin} Test Case
  */
-#[CoversClass(Plugin::class)]
-#[CoversMethod(Plugin::class, 'bootstrap')]
-#[CoversMethod(Plugin::class, 'console')]
+#[CoversClass(WebToolsPlugin::class)]
+#[CoversMethod(WebToolsPlugin::class, 'bootstrap')]
+#[CoversMethod(WebToolsPlugin::class, 'console')]
 class PluginTest extends TestCase
 {
     /**

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
  * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
  */
 
-use BEdita\WebTools\Plugin as WebToolsPlugin;
+use BEdita\WebTools\WebToolsPlugin;
 use Cake\Cache\Cache;
 use Cake\Core\Configure;
 use Cake\Core\Plugin;

--- a/tests/test_app/TestApp/Application.php
+++ b/tests/test_app/TestApp/Application.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace TestApp;
 
-use BEdita\WebTools\Plugin;
+use BEdita\WebTools\WebToolsPlugin;
 use Cake\Http\BaseApplication;
 use Cake\Http\MiddlewareQueue;
 use Cake\Routing\Middleware\RoutingMiddleware;
@@ -24,7 +24,7 @@ class Application extends BaseApplication
      */
     public function bootstrap(): void
     {
-        $this->addPlugin(new Plugin());
+        $this->addPlugin(new WebToolsPlugin());
     }
 
     /**


### PR DESCRIPTION
This fixes a deprecation in cakephp 5.3: 
```
Since 5.3.0: Loading plugins with a plugin class named `Plugin` is deprecated. Rename the class to `WebToolsPlugin` instead.
```