### PR TITLE
Use firebase php-jwt 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "php": ">=8.3",
         "bedita/php-sdk": "^4.2.0",
         "cakephp/cakephp": "^5.0",
-        "firebase/php-jwt": "^6.9",
+        "firebase/php-jwt": "^7.0",
         "cakephp/twig-view": "^2"
     },
     "require-dev": {


### PR DESCRIPTION
This is to fix a security advisory [https://packagist.org/security-advisories/PKSA-y2cr-5h3j-g3ys] on `firebase/php-jwt` < 7.

This fixes `composer install` too.